### PR TITLE
Align custom category tooltip anchors with vanilla positioning

### DIFF
--- a/Nvk3UT_Tooltips.lua
+++ b/Nvk3UT_Tooltips.lua
@@ -549,6 +549,53 @@ local function _nvkTooltipRow(tt, leftText, rightText)
   tt:AddLine(zo_strformat("<<1>>   |cAAAAAA<<2>>|r", leftText, rightText), "ZoFontGameSmall")
 end
 
+local function _nvkInitializeCategoryTooltip(control)
+  local tooltip = AchievementTooltip
+  if not tooltip or not control or not control.GetCenter then
+    return nil
+  end
+
+  ClearTooltip(tooltip)
+  if tooltip.SetClampedToScreen then
+    tooltip:SetClampedToScreen(true)
+  end
+  if InformationTooltip and InformationTooltip.SetClampedToScreen then
+    InformationTooltip:SetClampedToScreen(true)
+  end
+
+  local controlCenterX = select(1, control:GetCenter())
+  local referenceX
+  local parent = control.GetParent and control:GetParent()
+
+  while parent and parent.GetCenter do
+    if parent.GetWidth and parent:GetWidth() > 0 then
+      referenceX = select(1, parent:GetCenter())
+      break
+    end
+    parent = parent.GetParent and parent:GetParent()
+  end
+
+  if not referenceX and AchievementJournal and AchievementJournal.GetCenter then
+    referenceX = select(1, AchievementJournal:GetCenter())
+  end
+
+  if not referenceX and GuiRoot and GuiRoot.GetCenter then
+    referenceX = select(1, GuiRoot:GetCenter())
+  end
+
+  local tooltipPoint = TOPLEFT
+  local relativePoint = TOPRIGHT
+
+  if referenceX and controlCenterX and controlCenterX >= referenceX then
+    tooltipPoint = TOPRIGHT
+    relativePoint = TOPLEFT
+  end
+
+  InitializeTooltip(tooltip, control, tooltipPoint, 0, -104, relativePoint)
+
+  return tooltip
+end
+
 local function _nvkInitTooltip(control)
   local tt = AchievementTooltip or InformationTooltip
   InitializeTooltip(tt, control, BOTTOM, 0, -10)
@@ -614,13 +661,15 @@ local function _nvkCountFavorites()
 end
 
 local function _nvkRenderFavorites(control)
-  ClearTooltip(AchievementTooltip)
-  InitializeTooltip(AchievementTooltip, AchievementJournal, TOPRIGHT, 0, -104, TOPLEFT)
+  local tooltip = _nvkInitializeCategoryTooltip(control)
+  if not tooltip then
+    return
+  end
   local n = _nvkCountFavorites()
   local title = (GetString and GetString(SI_NAMED_FRIENDS_LIST_FAVOURITES_HEADER)) or "Favoriten"
   local line = string.format("%s |cfafafa(%s)|r", zo_strformat("<<1>>", title), ZO_CommaDelimitNumber(n or 0))
   local r, g, b = ZO_SELECTED_TEXT:UnpackRGB()
-  local _, lbl = AchievementTooltip:AddLine(line, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
+  local _, lbl = tooltip:AddLine(line, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
   if lbl then
     lbl:SetFont("$(MEDIUM_FONT)|$(KB_12)|soft-shadow-none")
     lbl:SetWrapMode(TEXT_WRAP_MODE_ELLIPSIS)
@@ -652,13 +701,15 @@ local function _nvkCountRecent()
 end
 
 local function _nvkRenderRecent(control)
-  ClearTooltip(AchievementTooltip)
-  InitializeTooltip(AchievementTooltip, AchievementJournal, TOPRIGHT, 0, -104, TOPLEFT)
+  local tooltip = _nvkInitializeCategoryTooltip(control)
+  if not tooltip then
+    return
+  end
   local n = _nvkCountRecent()
   local title = (GetString and GetString(SI_GAMEPAD_NOTIFICATIONS_CATEGORY_RECENT)) or "Kürzlich"
   local line = string.format("%s |cfafafa(%s)|r", zo_strformat("<<1>>", title), ZO_CommaDelimitNumber(n or 0))
   local r, g, b = ZO_SELECTED_TEXT:UnpackRGB()
-  local _, lbl = AchievementTooltip:AddLine(line, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
+  local _, lbl = tooltip:AddLine(line, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
   if lbl then
     lbl:SetFont("$(MEDIUM_FONT)|$(KB_12)|soft-shadow-none")
     lbl:SetWrapMode(TEXT_WRAP_MODE_ELLIPSIS)
@@ -703,8 +754,10 @@ local function _nvkCompletedPointsForKey(Comp, key)
 end
 
 local function _nvkRenderCompleted(control)
-  ClearTooltip(AchievementTooltip)
-  InitializeTooltip(AchievementTooltip, AchievementJournal, TOPRIGHT, 0, -104, TOPLEFT)
+  local tooltip = _nvkInitializeCategoryTooltip(control)
+  if not tooltip then
+    return
+  end
   local node = control and control.node
   if node == nil and control and control.GetParent then
     local p = control:GetParent()
@@ -770,8 +823,10 @@ local function _nvkMaxPointsForTop(topId, Todo)
 end
 
 local function _nvkRenderTodo(control)
-  ClearTooltip(AchievementTooltip)
-  InitializeTooltip(AchievementTooltip, AchievementJournal, TOPRIGHT, 0, -104, TOPLEFT)
+  local tooltip = _nvkInitializeCategoryTooltip(control)
+  if not tooltip then
+    return
+  end
   local names, keys, topIds, Todo = _nvkGetTodoSubs()
   local lines = {}
   for i = 1, (keys and #keys or 0) do
@@ -796,7 +851,7 @@ local function _nvkRenderTodo(control)
   if #lines > 0 then
     local text = table.concat(lines, "\n")
     local r, g, b = ZO_SELECTED_TEXT:UnpackRGB()
-    local _, lbl = AchievementTooltip:AddLine(text, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
+    local _, lbl = tooltip:AddLine(text, "", r, g, b, LEFT, MODIFY_TEXT_TYPE_NONE, TEXT_ALIGN_LEFT, false)
     if lbl then
       lbl:SetFont("$(MEDIUM_FONT)|$(KB_12)|soft-shadow-none")
       lbl:SetWrapMode(TEXT_WRAP_MODE_ELLIPSIS)


### PR DESCRIPTION
## Summary
- add a helper that anchors achievement tooltips relative to the hovered control and clamps them to the screen
- update the Abgeschlossen, Favoriten, Kürzlich, and To-Do custom tooltip renderers to use the new helper so they follow vanilla placement and layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7e46c0ec0832ab2206028026084ad