### PR TITLE
Filter completed achievements from Recent category

### DIFF
--- a/Nvk3UT_RecentData.lua
+++ b/Nvk3UT_RecentData.lua
@@ -85,9 +85,23 @@ function M.List(maxCount, sinceTs)
     table.sort(t, function(a,b) return a.ts > b.ts end)
     local res = {}
     local limit = tonumber(maxCount) or 0
+    local removed = 0
     for i=1,#t do
-        res[#res+1] = t[i].id
-        if limit > 0 and #res >= limit then break end
+        local id = t[i].id
+        local open = IsOpen(id)
+        if open then
+            if limit == 0 or #res < limit then
+                res[#res+1] = id
+            end
+        elseif id then
+            M.Clear(id)
+            removed = removed + 1
+        end
+    end
+    if U and U.d then
+        if removed > 0 then
+            U.d("[Nvk3UT][Recent][List] filtered", "removed:", removed)
+        end
     end
     return res
 end


### PR DESCRIPTION
## Summary
- filter the Recent saved entries so completed achievements are removed during list rebuilds
- log when removals occur while respecting the existing debug flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f803bf536c832a861bc7c7cc659771