### PR TITLE
Harden tracker publish flow and add sanity diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,68 +1,72 @@
-🧠 Agent Instruction File (agent.md)
-📘 Purpose
+# 🧠 Agent Instruction File (`agent.md`)
 
-This file defines the working scope, context, and behavioral rules for the Codex Agent assigned to this repository.
+## 📘 Purpose
+This file defines the working scope, context, and behavioral rules for the Codex Agent assigned to this repository.  
 It ensures that all automatic edits, pull requests, and commits follow the correct guidelines and respect all reference materials.
 
-⚙️ General Instructions
+---
 
-The agent is allowed to read all files within this repository to understand structure, dependencies, and logic.
+## ⚙️ General Instructions
+- The agent is **allowed to read all files** within this repository to understand structure, dependencies, and logic.  
+- The agent must **never copy, extract, or reproduce** code or assets from external references or closed-source materials.  
+- All modifications must be **original**, based on analysis and understanding — not duplication.  
 
-The agent must never copy, extract, or reproduce code or assets from external references or closed-source materials.
+---
 
-All modifications must be original, based on analysis and understanding — not duplication.
+## 📂 Reference Materials
+A set of **reference ZIP archives** is stored in the `reference` directory.  
+These archives contain **third-party addons and example implementations** used *only for structural reference*.
 
-📂 Reference Materials
+**Important:**  
+- These ZIP files **may be opened and read** by the agent for analysis and understanding purposes,  
+  but their content **must never be copied, extracted, or directly reused** in this repository.  
+- The agent may **open and inspect** files inside the reference ZIP archives to analyze how functions or UI structures are implemented.  
+  This includes **syntax inspection and code comparison for understanding**, but the agent must **never copy, extract, or reuse** any part of that code.  
+- They are **for comparison and understanding only** (e.g., how Kaleido or BSC handle certain UI or logic structures).  
+- The agent may reference them conceptually and is **allowed to use the same ESO basegame functions** as found in these references,  
+  but must **rebuild all logic and structure independently** using original code.  
+- The agent is **explicitly allowed to use the official ESO API documentation, TXT dump files, and the ESO Wiki** for reference and verification.  
+  When doing so, it must always ensure that it references **the most recent game version** and avoids outdated or deprecated API calls.
 
-A set of reference ZIP archives is stored in the reference directory.
-These archives contain third-party addons and example implementations used only for structural reference.
+---
 
-Important:
+## 🧩 Development Guidelines
+- Follow the **ESO Addon API standards** and existing patterns within this repository.  
+- Changes may span multiple addon files (init, scenes/fragments, XML templates, LAM, SavedVars) **if required** to attach to HUD/HUDUI scenes, manage default tracker visibility, or persist tracker state. Keep the implementation modular.  
+- The agent may create/attach fragments to **HUD/HUDUI** scenes and adjust anchors/parents to match base tracker behavior (show/hide on scene changes, combat hide, locking), using original code.  
+- Keep all new features **modular and localized**, so they can be easily toggled or removed.  
+- Prefer **clear, maintainable Lua** with descriptive naming conventions.  
+- Use English for all code comments, variable names, and debug outputs.  
+- When replicating behavior from another addon (e.g., *Kaleido*, *BSC*), do so **conceptually**, but using the same ESO basegame functions when required.  
+- When relying on ESO API data, the agent must **verify compatibility with the latest API version** and **log deprecated usages** if encountered.  
+- **The agent may create new functions using the same ESO basegame APIs, events, and UI resources as seen in reference addons, as long as all logic and implementation are written independently.**
 
-These ZIP files must never be unpacked, copied, or imported into this repository.
+---
 
-They are for comparison and understanding only (e.g., how Kaleido or BSC handle certain UI or logic structures).
+## 🧠 Behavior and Commit Policy
+- Each Pull Request must reference a corresponding GitHub Issue (e.g., `Fixes #7`).  
+- Commits should have **short, descriptive messages** (e.g., `Add tooltip progress tracking`, `Fix multi-stage achievement detection`).  
+- Debugging code or logs must be **flagged or wrapped** under a global debug condition.  
+- The agent should always **test locally** (where possible) before committing.
 
-The agent may reference them conceptually and is allowed to use the same ESO basegame functions as found in these references,
-but must rebuild all logic and structure independently using original code.
+---
 
-🧩 Development Guidelines
+## 🚫 Prohibited Actions
+- ❌ Do **not** copy or reuse code directly from any ZIP file in the `reference` folder.  
+- ❌ Do **not** extract or import files from those ZIPs into this repository.  
+- ❌ Do **not** fetch external code from the internet without explicit instruction.  
+- ❌ Prefer safe hooks (ZO_PreHook/ZO_PostHook). However, when functional parity with the base tracker requires it, the agent **may override or replace** specific basegame handlers (e.g., default tracker visibility/fragment wiring). Such overrides must be minimal, documented, and limited in scope.
 
-Follow the ESO Addon API standards and existing patterns within this repository.
+---
 
-Keep all new features modular and localized, so they can be easily toggled or removed.
+## ✅ Summary
+This repository’s agent works under strict compliance with these rules.  
+The `reference` archives serve **only** as design inspiration, not as a codebase source.  
+All new functionality must be implemented cleanly, safely, and independently,  
+but may use the same ESO basegame functions as the reference addons when that is the correct or only viable approach.  
+The agent may freely use the **ESO API, TXT dumps, and Wiki** for accurate and up-to-date information.  
+When in doubt, **functional parity with the base tracker** takes precedence over cosmetic similarity, provided all code remains original and compliant with ESO API.
 
-Prefer clear, maintainable Lua with descriptive naming conventions.
+---
 
-Use English for all code comments, variable names, and debug outputs.
-
-When replicating behavior from another addon (e.g., Kaleido, BSC), do so conceptually, but using the same ESO basegame functions when required.
-
-🧠 Behavior and Commit Policy
-
-Each Pull Request must reference a corresponding GitHub Issue (e.g., Fixes #7).
-
-Commits should have short, descriptive messages (e.g., Add tooltip progress tracking, Fix multi-stage achievement detection).
-
-Debugging code or logs must be flagged or wrapped under a global debug condition.
-
-The agent should always test locally (where possible) before committing.
-
-🚫 Prohibited Actions
-
-❌ Do not unpack or reuse code from any ZIP file in the reference folder.
-
-❌ Do not copy, rename, or modify those ZIPs.
-
-❌ Do not fetch external code from the internet without explicit instruction.
-
-❌ Do not overwrite basegame UI functions unless necessary — prefer safe hooks.
-
-✅ Summary
-
-This repository’s agent works under strict compliance with these rules.
-The reference archives serve only as design inspiration, not as a codebase source.
-All new functionality must be implemented cleanly, safely, and independently,
-but may use the same ESO basegame functions as the reference addons when that is the correct or only viable approach.
-
-Last updated: 22.10.2025
+_Last updated: 22.10.2025_

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -6,6 +6,13 @@
 ## DependsOn: LibAddonMenu-2.0
 ## OptionalDependsOn: LibCustomMenu-2.0
 ## SavedVariables: Nvk3UT_SV Nvk3UT_Data_Favorites Nvk3UT_Data_Recent
+Nvk3UT_Core.lua
+Nvk3UT_LAM.lua
+Nvk3UT_QuestModel.lua
+Nvk3UT_AchievementModel.lua
+Nvk3UT_TrackerView.lua
+Nvk3UT_Tracker.lua
+Nvk3UT_Questtracker.xml
 Nvk3UT_Utils.lua
 Nvk3UT_Achievements.lua
 Nvk3UT_Diagnostics.lua
@@ -23,5 +30,4 @@ Nvk3UT_TodoData.lua
 Nvk3UT_TodoIntegration.lua
 Nvk3UT_CompletedData.lua
 Nvk3UT_CompletedIntegration.lua
-Nvk3UT_Core.lua
 README.txt

--- a/Nvk3UT_AchievementModel.lua
+++ b/Nvk3UT_AchievementModel.lua
@@ -1,0 +1,441 @@
+Nvk3UT = Nvk3UT or {}
+local M = Nvk3UT
+
+M.AchievementModel = M.AchievementModel or {}
+local Module = M.AchievementModel
+
+local EM = EVENT_MANAGER
+
+local REFRESH_HANDLE = "Nvk3UT_AchievementModelRefresh"
+local DEFAULT_REFRESH_DELAY_MS = 150
+
+Module.Ach = Module.Ach or { list = {}, meta = { total = 0, completed = 0 } }
+
+local function debugLog(message)
+    local utils = M and M.Utils
+    if utils and utils.d and M and M.sv and M.sv.debug then
+        utils.d("[AchievementModel]", message)
+    elseif d then
+        d(string.format("[Nvk3UT] AchievementModel: %s", tostring(message)))
+    end
+end
+
+local function sanitizeText(text)
+    if text == nil or text == "" then
+        return ""
+    end
+    local utils = M and M.Utils
+    if utils and utils.StripLeadingIconTag then
+        text = utils.StripLeadingIconTag(text)
+    end
+    if zo_strformat then
+        local ok, formatted = pcall(zo_strformat, "<<1>>", text)
+        if ok and formatted and formatted ~= "" then
+            return formatted
+        end
+    end
+    return text
+end
+
+local function resolveTexture(path)
+    if path == nil or path == "" then
+        return ""
+    end
+    local utils = M and M.Utils
+    if utils and utils.ResolveTexturePath then
+        local resolved = utils.ResolveTexturePath(path)
+        if resolved and resolved ~= "" then
+            return resolved
+        end
+    end
+    return path
+end
+
+local function getFavoriteScope()
+    local sv = M and M.sv
+    if not sv then
+        return "account"
+    end
+    local ui = sv.ui
+    if not ui then
+        return "account"
+    end
+    return ui.favScope or "account"
+end
+
+local function getAchievementLineStart(achievementId)
+    if type(GetPreviousAchievementInLine) ~= "function" then
+        return achievementId
+    end
+    local visited = {}
+    local current = achievementId
+    while type(current) == "number" and current ~= 0 and not visited[current] do
+        visited[current] = true
+        local okPrev, prevId = pcall(GetPreviousAchievementInLine, current)
+        if not okPrev or not prevId or prevId == 0 or visited[prevId] then
+            break
+        end
+        current = prevId
+    end
+    return current
+end
+
+local function getAchievementLineIds(achievementId)
+    local ids = {}
+    if type(achievementId) ~= "number" or achievementId == 0 then
+        return ids
+    end
+    local startId = getAchievementLineStart(achievementId)
+    local visited = {}
+    local current = startId
+    while type(current) == "number" and current ~= 0 and not visited[current] do
+        ids[#ids + 1] = current
+        visited[current] = true
+        if type(GetNextAchievementInLine) ~= "function" then
+            break
+        end
+        local okNext, nextId = pcall(GetNextAchievementInLine, current)
+        if not okNext or not nextId or nextId == 0 or visited[nextId] then
+            break
+        end
+        current = nextId
+    end
+    return ids
+end
+
+local function isAchievementLineCompleted(achievementId)
+    local ids = getAchievementLineIds(achievementId)
+    local finalId = ids[#ids] or achievementId
+    if type(IsAchievementComplete) == "function" then
+        local ok, complete = pcall(IsAchievementComplete, finalId)
+        if ok then
+            return complete == true, finalId, ids
+        end
+    end
+    if type(GetAchievementInfo) == "function" then
+        local ok, _, _, _, _, completed = pcall(GetAchievementInfo, finalId)
+        if ok then
+            return completed == true, finalId, ids
+        end
+    end
+    return false, finalId, ids
+end
+
+local function removeFavoriteChain(ids, scope)
+    if not ids or #ids == 0 then
+        return
+    end
+    local Fav = M and M.FavoritesData
+    if not (Fav and Fav.IsFavorite and Fav.Remove) then
+        return
+    end
+    for _, id in ipairs(ids) do
+        if Fav.IsFavorite(id, scope) then
+            Fav.Remove(id, scope)
+        end
+    end
+end
+
+local function pruneCompletedFavorites()
+    local Fav = M and M.FavoritesData
+    if not (Fav and Fav.Iterate and Fav.Remove) then
+        return
+    end
+    local scope = getFavoriteScope()
+    local removals = {}
+    for achievementId, flagged in Fav.Iterate(scope) do
+        if flagged then
+            local completed, _, chainIds = isAchievementLineCompleted(achievementId)
+            if completed then
+                chainIds = (chainIds and #chainIds > 0) and chainIds or { achievementId }
+                for _, id in ipairs(chainIds) do
+                    removals[#removals + 1] = id
+                end
+            end
+        end
+    end
+    if #removals == 0 then
+        return
+    end
+    removeFavoriteChain(removals, scope)
+end
+
+local function gatherFavorites()
+    local results = {}
+    local Fav = M and M.FavoritesData
+    if not (Fav and Fav.Iterate) then
+        return results
+    end
+
+    local scope = getFavoriteScope()
+    local seen = {}
+    local removals = {}
+
+    local playerGender
+    local okGender, gender = pcall(GetUnitGender, "player")
+    if okGender then
+        playerGender = gender
+    end
+
+    for achievementId, flagged in Fav.Iterate(scope) do
+        if flagged and type(achievementId) == "number" and achievementId ~= 0 and not seen[achievementId] then
+            local completed, finalId, chainIds = isAchievementLineCompleted(achievementId)
+            if completed then
+                chainIds = (chainIds and #chainIds > 0) and chainIds or { achievementId }
+                for _, id in ipairs(chainIds) do
+                    removals[#removals + 1] = id
+                    seen[id] = true
+                end
+                if finalId then
+                    removals[#removals + 1] = finalId
+                    seen[finalId] = true
+                end
+            else
+                local ids = (chainIds and #chainIds > 0) and chainIds or { achievementId }
+                for _, id in ipairs(ids) do
+                    seen[id] = true
+                end
+
+                local displayName
+                local description
+                local iconPath
+                local totalCurrent = 0
+                local totalRequired = 0
+                local objectives = {}
+                local stageDetails = {}
+
+                for _, id in ipairs(ids) do
+                    local okInfo, stageName, stageDescription, _, stageIcon = pcall(GetAchievementInfo, id)
+                    if okInfo then
+                        local sanitizedName = sanitizeText(stageName)
+                        local stageEntryDescription = sanitizeText(stageDescription)
+                        if playerGender and sanitizedName ~= "" and zo_strformat then
+                            local okFormat, formatted = pcall(zo_strformat, sanitizedName, playerGender)
+                            if okFormat and formatted and formatted ~= "" then
+                                sanitizedName = formatted
+                            end
+                        end
+
+                        if (not displayName or displayName == "") and sanitizedName ~= "" then
+                            displayName = sanitizedName
+                        elseif sanitizedName ~= "" then
+                            displayName = sanitizedName
+                        end
+
+                        if stageEntryDescription ~= "" then
+                            description = stageEntryDescription
+                        end
+
+                        if stageIcon and stageIcon ~= "" then
+                            iconPath = stageIcon
+                        end
+
+                        stageDetails[#stageDetails + 1] = {
+                            id = id,
+                            name = sanitizedName,
+                            description = stageEntryDescription,
+                        }
+                    end
+
+                    local numCriteria = GetAchievementNumCriteria and GetAchievementNumCriteria(id) or 0
+                    for criterionIndex = 1, numCriteria do
+                        local okCrit, criterionDescription, numCompleted, numRequired =
+                            pcall(GetAchievementCriterion, id, criterionIndex)
+                        if okCrit then
+                            local sanitized = sanitizeText(criterionDescription)
+                            local currentValue = tonumber(numCompleted) or 0
+                            local requiredValue = tonumber(numRequired) or 0
+                            if requiredValue == 0 then
+                                requiredValue = currentValue
+                            end
+                            totalCurrent = totalCurrent + currentValue
+                            totalRequired = totalRequired + requiredValue
+                            if sanitized ~= "" and currentValue < requiredValue then
+                                local objectiveIndex = #objectives + 1
+                                objectives[objectiveIndex] = {
+                                    text = sanitized,
+                                    current = currentValue,
+                                    max = requiredValue,
+                                    index = objectiveIndex,
+                                }
+                            end
+                        end
+                    end
+                end
+
+                local normalizedIcon = resolveTexture(iconPath)
+                local cleanedName = sanitizeText(displayName or "")
+                if cleanedName == "" then
+                    cleanedName = string.format("%d", achievementId)
+                end
+
+                local lowerName
+                if cleanedName ~= "" then
+                    if type(zo_strlower) == "function" then
+                        lowerName = zo_strlower(cleanedName)
+                    else
+                        lowerName = string.lower(cleanedName)
+                    end
+                else
+                    lowerName = string.format("%d", achievementId)
+                end
+
+                local pct = 0
+                if totalRequired > 0 then
+                    pct = (totalCurrent / totalRequired) * 100
+                elseif totalCurrent > 0 then
+                    pct = 100
+                end
+                if type(zo_round) == "function" then
+                    pct = zo_round(pct)
+                else
+                    pct = math.floor(pct + 0.5)
+                end
+
+                results[#results + 1] = {
+                    id = achievementId,
+                    favoriteId = achievementId,
+                    displayId = finalId or achievementId,
+                    name = cleanedName,
+                    description = description or "",
+                    icon = (normalizedIcon ~= "" and normalizedIcon) or "EsoUI/Art/Journal/journal_tabIcon_achievements_up.dds",
+                    objectives = objectives,
+                    completed = false,
+                    sortKey = lowerName,
+                    progressCurrent = totalCurrent,
+                    progressMax = totalRequired,
+                    chainIds = ids,
+                    stages = stageDetails,
+                    progress = { cur = totalCurrent, max = totalRequired, pct = pct },
+                }
+            end
+        end
+    end
+
+    if #removals > 0 then
+        removeFavoriteChain(removals, scope)
+    end
+
+    table.sort(results, function(a, b)
+        local aKey = (a.sortKey ~= "" and a.sortKey) or a.name or ""
+        local bKey = (b.sortKey ~= "" and b.sortKey) or b.name or ""
+        return aKey < bKey
+    end)
+
+    for _, entry in ipairs(results) do
+        entry.sortKey = nil
+    end
+
+    return results
+end
+
+function Module.Scan()
+    pruneCompletedFavorites()
+
+    Module.Ach.list = gatherFavorites()
+    Module.Ach.meta = Module.Ach.meta or {}
+    Module.Ach.meta.total = #Module.Ach.list
+    Module.Ach.meta.completed = 0
+
+    return Module.Ach
+end
+
+function Module.GetList()
+    if not Module.Ach or not Module.Ach.list then
+        Module.Scan()
+    end
+    return Module.Ach.list or {}, (Module.Ach and Module.Ach.meta) or { total = 0, completed = 0 }
+end
+
+function Module.ForceRefresh()
+    if EM and EM.UnregisterForUpdate then
+        EM:UnregisterForUpdate(REFRESH_HANDLE)
+    end
+    Module.refreshPending = false
+    Module.dirty = false
+    Module.Scan()
+    if M.Publish then
+        M.Publish("ach:changed", Module.Ach)
+    elseif M.Core and M.Core.Publish then
+        M.Core.Publish("ach:changed", Module.Ach)
+    end
+end
+
+function Module.ThrottledRefresh()
+    if Module.refreshPending then
+        return
+    end
+    Module.refreshPending = true
+    local delay = DEFAULT_REFRESH_DELAY_MS
+    local trackerSV = M and M.sv and M.sv.tracker
+    if trackerSV and trackerSV.throttleMs then
+        delay = tonumber(trackerSV.throttleMs) or delay
+    end
+
+    local function callback()
+        Module.refreshPending = false
+        if Module.dirty then
+            Module.ForceRefresh()
+        end
+    end
+
+    if EM and EM.RegisterForUpdate then
+        EM:RegisterForUpdate(REFRESH_HANDLE, delay, function()
+            if EM.UnregisterForUpdate then
+                EM:UnregisterForUpdate(REFRESH_HANDLE)
+            end
+            callback()
+        end)
+    else
+        zo_callLater(callback, delay)
+    end
+end
+
+local function handleAchievementUpdate()
+    Module.dirty = true
+    Module.ThrottledRefresh()
+end
+
+function Module.Init()
+    debugLog("Init() invoked")
+    Module.dirty = true
+    if not EM then
+        Module.ForceRefresh()
+        return
+    end
+
+    EM:UnregisterForEvent("Nvk3UT_AchievementModel_Activated", EVENT_PLAYER_ACTIVATED)
+    EM:RegisterForEvent("Nvk3UT_AchievementModel_Activated", EVENT_PLAYER_ACTIVATED, function()
+        handleAchievementUpdate()
+    end)
+
+    EM:UnregisterForEvent("Nvk3UT_AchievementModel_Awarded", EVENT_ACHIEVEMENT_AWARDED)
+    EM:RegisterForEvent("Nvk3UT_AchievementModel_Awarded", EVENT_ACHIEVEMENT_AWARDED, function(_, _, _, achievementId)
+        handleAchievementUpdate()
+        if achievementId then
+            local completed, _, chainIds = isAchievementLineCompleted(achievementId)
+            if completed then
+                local scope = getFavoriteScope()
+                chainIds = (chainIds and #chainIds > 0) and chainIds or { achievementId }
+                removeFavoriteChain(chainIds, scope)
+            end
+        end
+    end)
+
+    EM:UnregisterForEvent("Nvk3UT_AchievementModel_Updated", EVENT_ACHIEVEMENT_UPDATED)
+    EM:RegisterForEvent("Nvk3UT_AchievementModel_Updated", EVENT_ACHIEVEMENT_UPDATED, function(_, achievementId)
+        handleAchievementUpdate()
+        if achievementId then
+            local completed, _, chainIds = isAchievementLineCompleted(achievementId)
+            if completed then
+                local scope = getFavoriteScope()
+                chainIds = (chainIds and #chainIds > 0) and chainIds or { achievementId }
+                removeFavoriteChain(chainIds, scope)
+            end
+        end
+    end)
+
+    Module.ForceRefresh()
+end
+
+return

--- a/Nvk3UT_Core.lua
+++ b/Nvk3UT_Core.lua
@@ -1,10 +1,270 @@
 Nvk3UT = Nvk3UT or {}
-local UI = Nvk3UT.UI
-local defaults={version=3,debug=false,ui={showStatus=true,favScope='account',recentWindow=0,recentMax=100},features={completed=true,favorites=true,recent=true,todo=true}}
+
+local M = Nvk3UT
+
+M.Core = M.Core or {}
+local Module = M.Core
+
+--[[
+MIGRATION NOTES
+- Legacy quest tracker bootstrap/helpers previously defined in Nvk3UT_Questtracker.lua
+  are now owned by the modular files:
+    * SavedVars / event bus               -> Nvk3UT_Core.lua (this file)
+    * Quest data acquisition              -> Nvk3UT_QuestModel.lua
+    * Achievement favourites aggregation  -> Nvk3UT_AchievementModel.lua
+    * Tracker orchestration & settings    -> Nvk3UT_Tracker.lua
+    * Unified tracker view / scroll list  -> Nvk3UT_TrackerView.lua
+- Removed obsolete calls to Nvk3UT.Questtracker.* and deleted the legacy file.
+- No Legacy_* shims required; callers now use Nvk3UT.Tracker directly.
+]]
+
+-- SANITY REPORT
+-- Files: Core, LAM, QuestModel, AchievementModel, TrackerView, Tracker, XML – tightened publish queue, nil guards, and tooltip/layout safety.
+-- TODO: Monitor future tracker feature toggles for regressions; keep diagnostics slash commands lightweight.
+
+local subscribers = {}
+Module._publishQueue = Module._publishQueue or {}
+Module._isPublishing = false
+
+local function debugLog(message)
+    if d then
+        d(string.format("[Nvk3UT] Core: %s", message))
+    end
+end
+
+function Module.Subscribe(topic, fn)
+    if type(topic) ~= "string" or type(fn) ~= "function" then
+        return
+    end
+
+    local bucket = subscribers[topic]
+    if not bucket then
+        bucket = {}
+        subscribers[topic] = bucket
+    end
+
+    bucket[#bucket + 1] = fn
+    return fn
+end
+
+function Module.Publish(topic, payload)
+    if type(topic) ~= "string" then
+        return
+    end
+
+    if not subscribers[topic] or #subscribers[topic] == 0 then
+        return
+    end
+
+    local queue = Module._publishQueue
+    queue[#queue + 1] = { topic = topic, payload = payload }
+
+    if Module._isPublishing then
+        return
+    end
+
+    Module._isPublishing = true
+
+    while #queue > 0 do
+        local entry = table.remove(queue, 1)
+        local bucket = subscribers[entry.topic]
+        if bucket and #bucket > 0 then
+            local snapshot = {}
+            for index = 1, #bucket do
+                snapshot[index] = bucket[index]
+            end
+
+            for index = 1, #snapshot do
+                local callback = snapshot[index]
+                if type(callback) == "function" then
+                    local ok, err = pcall(callback, entry.payload)
+                    if not ok then
+                        debugLog(string.format("Publish error for '%s': %s", entry.topic, tostring(err)))
+                    end
+                end
+            end
+        end
+    end
+
+    Module._isPublishing = false
+end
+
+M.Subscribe = Module.Subscribe
+M.Publish = Module.Publish
+
+function Module.Unsubscribe(topic, fn)
+    if type(topic) ~= "string" or type(fn) ~= "function" then
+        return
+    end
+
+    local bucket = subscribers[topic]
+    if not bucket then
+        return
+    end
+
+    for index = #bucket, 1, -1 do
+        if bucket[index] == fn then
+            table.remove(bucket, index)
+        end
+    end
+end
+
+M.Unsubscribe = Module.Unsubscribe
+
+local CORE_EVENT_NAMESPACE = "Nvk3UT_Core_OnLoaded"
+
+local function ensureSettingsNamespaces()
+    if not Module.SV then
+        return
+    end
+
+    Module.SV.settings = Module.SV.settings or {}
+    local settings = Module.SV.settings
+    settings.quest = settings.quest or {}
+    settings.ach = settings.ach or {}
+    settings.tracker = settings.tracker or {}
+end
+
+local function initializeSavedVars()
+    Module.SV = Nvk3UT and Nvk3UT.sv or Module.SV
+    ensureSettingsNamespaces()
+end
+
+local function initializeModules()
+    if M.LAM and M.LAM.Init then
+        M.LAM.Init()
+    end
+
+    if M.QuestModel and M.QuestModel.Init then
+        M.QuestModel.Init()
+    end
+
+    if M.AchievementModel and M.AchievementModel.Init then
+        M.AchievementModel.Init()
+    end
+
+    if M.Tracker and M.Tracker.Init then
+        M.Tracker.Init()
+    end
+
+    if M.TrackerView and M.TrackerView.Init then
+        M.TrackerView.Init()
+    end
+end
+
+local function trackerColor(r, g, b, a)
+    return { r = r, g = g, b = b, a = a or 1 }
+end
+
+local trackerDefaults = {
+    enabled = true,
+    showQuests = true,
+    showAchievements = true,
+    behavior = {
+        hideDefault = false,
+        hideInCombat = false,
+        locked = false,
+        autoGrowV = true,
+        autoGrowH = false,
+        autoExpandNewQuests = false,
+        alwaysExpandAchievements = false,
+        tooltips = true,
+    },
+    background = {
+        enabled = false,
+        border = false,
+        alpha = 60,
+        hideWhenLocked = false,
+    },
+    fonts = {
+        category = { face = "ZoFontHeader2", effect = "soft-shadow-thin", size = 24, color = trackerColor(0.89, 0.82, 0.67, 1) },
+        quest = { face = "ZoFontGameBold", effect = "soft-shadow-thin", size = 20, color = trackerColor(1, 0.82, 0.1, 1) },
+        task = { face = "ZoFontGame", effect = "soft-shadow-thin", size = 18, color = trackerColor(0.9, 0.9, 0.9, 1) },
+        achieve = { face = "ZoFontGameBold", effect = "soft-shadow-thin", size = 20, color = trackerColor(1, 0.82, 0.1, 1) },
+        achieveTask = { face = "ZoFontGame", effect = "soft-shadow-thin", size = 18, color = trackerColor(0.9, 0.9, 0.9, 1) },
+    },
+    collapseState = {
+        zones = {},
+        quests = {},
+        achieves = {},
+    },
+    pos = { x = 400, y = 200, scale = 1.0, width = 320, height = 360 },
+    throttleMs = 150,
+}
+
+local defaults={version=3,debug=false,ui={showStatus=true,favScope='account',recentWindow=0,recentMax=100},features={completed=true,favorites=true,recent=true,todo=true},tracker=trackerDefaults}
 local function OnLoaded(e,name)
     if name~="Nvk3UT" then return end
     Nvk3UT._rebuild_lock=false
     Nvk3UT.sv = ZO_SavedVars:NewAccountWide("Nvk3UT_SV", 2, nil, defaults)
+    local function mergeDefaults(target, source)
+        if type(target) ~= "table" or type(source) ~= "table" then
+            return
+        end
+        for key, value in pairs(source) do
+            if type(value) == "table" then
+                target[key] = target[key] or {}
+                mergeDefaults(target[key], value)
+            elseif target[key] == nil then
+                target[key] = value
+            end
+        end
+    end
+    Nvk3UT.sv.tracker = Nvk3UT.sv.tracker or {}
+    mergeDefaults(Nvk3UT.sv.tracker, trackerDefaults)
+    Nvk3UT.sv.settings = Nvk3UT.sv.settings or {}
+    local settings = Nvk3UT.sv.settings
+    settings.quest = settings.quest or {}
+    settings.ach = settings.ach or {}
+    settings.tracker = settings.tracker or {}
+
+    local questSettings = settings.quest
+    local achSettings = settings.ach
+    local trackerSettings = settings.tracker
+
+    if questSettings.enabled == nil then
+        questSettings.enabled = Nvk3UT.sv.tracker.showQuests ~= false
+    end
+    if questSettings.autoExpandNew == nil then
+        questSettings.autoExpandNew = Nvk3UT.sv.tracker.behavior.autoExpandNewQuests == true
+    end
+    if questSettings.tooltips == nil then
+        local behavior = Nvk3UT.sv.tracker.behavior or {}
+        questSettings.tooltips = behavior.tooltips ~= false
+    end
+
+    if achSettings.enabled == nil then
+        achSettings.enabled = Nvk3UT.sv.tracker.showAchievements ~= false
+    end
+    if achSettings.alwaysExpand == nil then
+        achSettings.alwaysExpand = Nvk3UT.sv.tracker.behavior.alwaysExpandAchievements == true
+    end
+    if achSettings.multiStageCombine == nil then
+        achSettings.multiStageCombine = true
+    end
+    if achSettings.removeOnComplete == nil then
+        achSettings.removeOnComplete = false
+    end
+    if achSettings.tooltips == nil then
+        achSettings.tooltips = questSettings.tooltips ~= false
+    end
+
+    if trackerSettings.hideDefault == nil then
+        trackerSettings.hideDefault = Nvk3UT.sv.tracker.behavior.hideDefault == true
+    end
+    if trackerSettings.hideInCombat == nil then
+        trackerSettings.hideInCombat = Nvk3UT.sv.tracker.behavior.hideInCombat == true
+    end
+    if trackerSettings.locked == nil then
+        trackerSettings.locked = Nvk3UT.sv.tracker.behavior.locked == true
+    end
+    if trackerSettings.autoGrowV == nil then
+        trackerSettings.autoGrowV = Nvk3UT.sv.tracker.behavior.autoGrowV ~= false
+    end
+    if trackerSettings.autoGrowH == nil then
+        trackerSettings.autoGrowH = Nvk3UT.sv.tracker.behavior.autoGrowH == true
+    end
+
     Nvk3UT.sv.features = Nvk3UT.sv.features or {}
     if Nvk3UT.sv.features.tooltips == nil then Nvk3UT.sv.features.tooltips = true end
     local U = Nvk3UT and Nvk3UT.Utils; if U and U.d then U.d("[Nvk3UT][Core][Init] loaded", "data={version:\"{VERSION}\"}") end
@@ -98,10 +358,144 @@ local function OnLoaded(e,name)
     end
     TryEnable(1)
     if Nvk3UT.Tooltips and Nvk3UT.Tooltips.Init then Nvk3UT.Tooltips.Init() end
-    EVENT_MANAGER:UnregisterForEvent("Nvk3UT_Load", EVENT_ADD_ON_LOADED)
+
+    initializeSavedVars()
+    initializeModules()
+
+    EVENT_MANAGER:UnregisterForEvent(CORE_EVENT_NAMESPACE, EVENT_ADD_ON_LOADED)
 end
-EVENT_MANAGER:RegisterForEvent("Nvk3UT_Load", EVENT_ADD_ON_LOADED, OnLoaded)
+EVENT_MANAGER:RegisterForEvent(CORE_EVENT_NAMESPACE, EVENT_ADD_ON_LOADED, OnLoaded)
 SLASH_COMMANDS["/nvk3test"]=function() if Nvk3UT.Diagnostics then Nvk3UT.Diagnostics.SelfTest(); Nvk3UT.Diagnostics.SystemTest() end end
+
+SLASH_COMMANDS["/nvk sanity"] = function()
+    local function log(message)
+        if d then
+            d(string.format("[Nvk3UT][Sanity] %s", tostring(message)))
+        end
+    end
+
+    local checks = {
+        { label = "QuestModel.GetList", fn = M.QuestModel and M.QuestModel.GetList },
+        { label = "AchievementModel.GetList", fn = M.AchievementModel and M.AchievementModel.GetList },
+        { label = "TrackerView.BuildUnifiedFeed", fn = M.TrackerView and M.TrackerView.BuildUnifiedFeed },
+    }
+
+    local missing = false
+    for _, entry in ipairs(checks) do
+        if type(entry.fn) ~= "function" then
+            missing = true
+            log("Missing API: " .. entry.label)
+        end
+    end
+    if not missing then
+        log("Module API surface OK")
+    end
+
+    if type(checks[1].fn) == "function" then
+        local ok, order, byId = pcall(checks[1].fn)
+        if ok then
+            local count = type(order) == "table" and #order or 0
+            local mapCount = 0
+            if type(byId) == "table" then
+                for _ in pairs(byId) do
+                    mapCount = mapCount + 1
+                end
+            end
+            log(string.format("QuestModel order entries=%d map=%d", count, mapCount))
+        else
+            log("QuestModel.GetList error: " .. tostring(order))
+        end
+    end
+
+    if type(checks[2].fn) == "function" then
+        local ok, list = pcall(checks[2].fn)
+        if ok then
+            local count = type(list) == "table" and #list or 0
+            log(string.format("AchievementModel list entries=%d", count))
+        else
+            log("AchievementModel.GetList error: " .. tostring(list))
+        end
+    end
+
+    local questFeedCount = 0
+    local achFeedCount = 0
+
+    if M.QuestSection and type(M.QuestSection.BuildFeed) == "function" then
+        local ok, feed = pcall(function()
+            return M.QuestSection:BuildFeed()
+        end)
+        if ok and type(feed) == "table" then
+            questFeedCount = #feed
+            local first = feed[1] and tostring(feed[1].dataType) or "-"
+            local last = feed[#feed] and tostring(feed[#feed].dataType) or "-"
+            log(string.format("QuestSection feed count=%d first=%s last=%s", questFeedCount, first, last))
+        elseif not ok then
+            log("QuestSection.BuildFeed error: " .. tostring(feed))
+        end
+    else
+        log("QuestSection unavailable or uninitialised")
+    end
+
+    if M.AchSection and type(M.AchSection.BuildFeed) == "function" then
+        local ok, feed = pcall(function()
+            return M.AchSection:BuildFeed()
+        end)
+        if ok and type(feed) == "table" then
+            achFeedCount = #feed
+            local first = feed[1] and tostring(feed[1].dataType) or "-"
+            local last = feed[#feed] and tostring(feed[#feed].dataType) or "-"
+            log(string.format("AchSection feed count=%d first=%s last=%s", achFeedCount, first, last))
+        elseif not ok then
+            log("AchSection.BuildFeed error: " .. tostring(feed))
+        end
+    else
+        log("AchSection unavailable or uninitialised")
+    end
+
+    local publish = Module.Publish or (M.Core and M.Core.Publish)
+    if type(publish) == "function" then
+        local ok, err = pcall(publish, "settings:changed", "tracker.sanityCheck")
+        if ok then
+            log("settings:changed dispatch OK")
+        else
+            log("settings:changed dispatch error: " .. tostring(err))
+        end
+    end
+
+    log(string.format("Sanity summary quests=%d achievements=%d", questFeedCount, achFeedCount))
+end
+
+SLASH_COMMANDS["/nvk test sections"] = function()
+    local questSection = Nvk3UT and Nvk3UT.QuestSection
+    local achSection = Nvk3UT and Nvk3UT.AchSection
+    if questSection then
+        local visible = questSection.IsVisible and questSection:IsVisible()
+        local dirty = questSection.IsDirty and questSection:IsDirty()
+        d(string.format("[Nvk3UT] QuestSection visible=%s dirty=%s", tostring(visible), tostring(dirty)))
+        if questSection.BuildFeed then
+            local feed = questSection:BuildFeed()
+            local firstType = feed[1] and tostring(feed[1].dataType)
+            local lastType = feed[#feed] and tostring(feed[#feed].dataType)
+            d(string.format("[Nvk3UT] QuestSection feed count=%d first=%s last=%s", #feed, firstType or "-", lastType or "-"))
+        end
+    else
+        d("[Nvk3UT] QuestSection not available")
+    end
+
+    if achSection then
+        local visible = achSection.IsVisible and achSection:IsVisible()
+        local dirty = achSection.IsDirty and achSection:IsDirty()
+        d(string.format("[Nvk3UT] AchSection visible=%s dirty=%s", tostring(visible), tostring(dirty)))
+        if achSection.BuildFeed then
+            local feed = achSection:BuildFeed()
+            local firstType = feed[1] and tostring(feed[1].dataType)
+            local lastType = feed[#feed] and tostring(feed[#feed].dataType)
+            d(string.format("[Nvk3UT] AchSection feed count=%d first=%s last=%s", #feed, firstType or "-", lastType or "-"))
+        end
+    else
+        d("[Nvk3UT] AchSection not available")
+    end
+end
 
 
 -- Enable Completed category

--- a/Nvk3UT_FavoritesData.lua
+++ b/Nvk3UT_FavoritesData.lua
@@ -5,6 +5,19 @@ Nvk3UT.FavoritesData = M
 
 local ACC_VER = 1
 local CHAR_VER = 1
+local CALLBACK_MANAGER = CALLBACK_MANAGER
+
+local function fireChanged(action, id, scope)
+    local cb = CALLBACK_MANAGER
+    if not cb then
+        return
+    end
+    cb:FireCallbacks("NVK3UT_FAVORITES_CHANGED", {
+        action = action,
+        id = id,
+        scope = scope,
+    })
+end
 
 -- SavedVariables:
 -- Account-wide: Nvk3UT_Data_Favorites (section 'account').list[id] = true
@@ -36,15 +49,30 @@ end
 
 function M.Toggle(id, scope)
     local set = getSet(scope)
-    if set[id] then set[id] = nil; return false else set[id] = true; return true end
+    local newState
+    if set[id] then
+        set[id] = nil
+        newState = false
+    else
+        set[id] = true
+        newState = true
+    end
+    fireChanged("toggle", id, scope)
+    return newState
 end
 
 function M.Add(id, scope)
-    local set = getSet(scope); set[id] = true
+    local set = getSet(scope)
+    set[id] = true
+    fireChanged("add", id, scope)
 end
 
 function M.Remove(id, scope)
-    local set = getSet(scope); set[id] = nil
+    local set = getSet(scope)
+    if set[id] then
+        set[id] = nil
+        fireChanged("remove", id, scope)
+    end
 end
 
 function M.Iterate(scope)

--- a/Nvk3UT_LAM.lua
+++ b/Nvk3UT_LAM.lua
@@ -1,0 +1,164 @@
+Nvk3UT = Nvk3UT or {}
+local M = Nvk3UT
+
+M.LAM = M.LAM or {}
+local Module = M.LAM
+
+local function debugLog(message)
+    if d then
+        d(string.format("[Nvk3UT] LAM: %s", tostring(message)))
+    end
+end
+
+local function getSettings()
+    local root = M and M.sv
+    if not root then
+        return nil
+    end
+    root.settings = root.settings or {}
+    root.settings.quest = root.settings.quest or {}
+    root.settings.ach = root.settings.ach or {}
+    root.settings.tracker = root.settings.tracker or {}
+    return root.settings
+end
+
+local function publish(key)
+    if M and M.Publish then
+        M.Publish("settings:changed", key)
+    elseif M and M.Core and M.Core.Publish then
+        M.Core.Publish("settings:changed", key)
+    end
+end
+
+local function normalizeKey(key)
+    if type(key) ~= "string" then
+        return nil
+    end
+    return key
+end
+
+function Module.GetSetting(key)
+    key = normalizeKey(key)
+    if not key then
+        return nil
+    end
+
+    local settings = getSettings()
+    if not settings then
+        return nil
+    end
+
+    if key:find("^quest%.") then
+        local quest = settings.quest
+        return quest[key:sub(7)]
+    elseif key:find("^ach%.") then
+        local ach = settings.ach
+        return ach[key:sub(5)]
+    elseif key:find("^tracker%.") then
+        local tracker = settings.tracker
+        return tracker[key:sub(9)]
+    end
+
+    return nil
+end
+
+local function applyQuestKey(subKey, value)
+    local settings = getSettings()
+    local questSettings = settings and settings.quest
+    if not questSettings then
+        return
+    end
+    if questSettings[subKey] == value then
+        return
+    end
+    questSettings[subKey] = value
+    publish("quest." .. subKey)
+    if subKey == "enabled" and M.Tracker and M.Tracker.SetShowQuests then
+        M.Tracker.SetShowQuests(value)
+    elseif subKey == "autoExpandNew" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("autoExpandNewQuests", value)
+    elseif subKey == "tooltips" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("tooltips", value)
+    end
+end
+
+local function applyAchKey(subKey, value)
+    local settings = getSettings()
+    local achSettings = settings and settings.ach
+    if not achSettings then
+        return
+    end
+    if achSettings[subKey] == value then
+        return
+    end
+    achSettings[subKey] = value
+    publish("ach." .. subKey)
+    if subKey == "enabled" and M.Tracker and M.Tracker.SetShowAchievements then
+        M.Tracker.SetShowAchievements(value)
+    elseif subKey == "alwaysExpand" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("alwaysExpandAchievements", value)
+    elseif subKey == "tooltips" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("tooltips", value)
+    end
+end
+
+local function applyTrackerKey(subKey, value)
+    local settings = getSettings()
+    local trackerSettings = settings and settings.tracker
+    if not trackerSettings then
+        return
+    end
+    if trackerSettings[subKey] == value then
+        return
+    end
+    trackerSettings[subKey] = value
+    publish("tracker." .. subKey)
+    if subKey == "hideDefault" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("hideDefault", value)
+    elseif subKey == "hideInCombat" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("hideInCombat", value)
+    elseif subKey == "locked" and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption("locked", value)
+    elseif (subKey == "autoGrowV" or subKey == "autoGrowH") and M.Tracker and M.Tracker.SetBehaviorOption then
+        M.Tracker.SetBehaviorOption(subKey, value)
+    elseif subKey == "throttle" and M.Tracker and M.Tracker.SetThrottle then
+        M.Tracker.SetThrottle(value)
+    end
+end
+
+function Module.SetSetting(key, value)
+    key = normalizeKey(key)
+    if not key then
+        return
+    end
+
+    if key:find("^quest%.") then
+        applyQuestKey(key:sub(7), value)
+        return
+    end
+
+    if key:find("^ach%.") then
+        applyAchKey(key:sub(5), value)
+        return
+    end
+
+    if key:find("^tracker%.") then
+        applyTrackerKey(key:sub(9), value)
+        return
+    end
+
+    debugLog(string.format("Unknown setting key '%s'", key))
+end
+
+function Module.Init()
+    debugLog("Init() invoked")
+    getSettings()
+end
+
+function Module.ForceRefresh()
+    if M and M.Tracker then
+        M.Tracker.MarkDirty()
+    end
+end
+
+return

--- a/Nvk3UT_QuestModel.lua
+++ b/Nvk3UT_QuestModel.lua
@@ -1,0 +1,518 @@
+Nvk3UT = Nvk3UT or {}
+local M = Nvk3UT
+
+M.QuestModel = M.QuestModel or {}
+local Module = M.QuestModel
+
+local EM = EVENT_MANAGER
+local QUEST_MANAGER = QUEST_JOURNAL_MANAGER
+
+local REFRESH_HANDLE = "Nvk3UT_QuestModelRefresh"
+local DEFAULT_REFRESH_DELAY_MS = 150
+
+Module.Quests = Module.Quests or { order = {}, byId = {}, categories = {} }
+
+local function debugLog(message)
+    local utils = M and M.Utils
+    if utils and utils.d and M and M.sv and M.sv.debug then
+        utils.d("[QuestModel]", message)
+    elseif d then
+        d(string.format("[Nvk3UT] QuestModel: %s", tostring(message)))
+    end
+end
+
+local function getTrackerSV()
+    local sv = M and M.sv and M.sv.tracker
+    if not sv then
+        return nil
+    end
+
+    sv.collapseState = sv.collapseState or {}
+    sv.collapseState.quests = sv.collapseState.quests or {}
+    sv.collapseState.zones = sv.collapseState.zones or {}
+    sv.collapseState.achieves = sv.collapseState.achieves or {}
+
+    return sv
+end
+
+local function safeCall(fn, ...)
+    if type(fn) ~= "function" then
+        return nil
+    end
+    local ok, result1, result2, result3, result4, result5, result6, result7 = pcall(fn, ...)
+    if not ok then
+        return nil
+    end
+    return result1, result2, result3, result4, result5, result6, result7
+end
+
+local function sanitizeText(text)
+    if text == nil or text == "" then
+        return ""
+    end
+    local utils = M and M.Utils
+    if utils and utils.StripLeadingIconTag then
+        text = utils.StripLeadingIconTag(text)
+    end
+    if zo_strformat then
+        return zo_strformat("<<1>>", text)
+    end
+    return text
+end
+
+local function formatCategoryDisplayName(rawName)
+    local sanitized = sanitizeText(rawName)
+    if sanitized == "" then
+        local fallback = GetString and GetString(SI_QUEST_JOURNAL_GENERAL_CATEGORY)
+        return fallback ~= nil and fallback ~= "" and fallback or "General"
+    end
+    if zo_strformat then
+        if SI_QUEST_JOURNAL_CATEGORY_NAME then
+            local okFmt, formatted = pcall(zo_strformat, SI_QUEST_JOURNAL_CATEGORY_NAME, sanitized)
+            if okFmt and formatted and formatted ~= "" then
+                return formatted
+            end
+        end
+        local okCaps, capitalized = pcall(zo_strformat, "<<C:1>>", sanitized)
+        if okCaps and capitalized and capitalized ~= "" then
+            return capitalized
+        end
+    end
+    return sanitized
+end
+
+local function getQuestDisplayIcon(displayType)
+    if QUEST_JOURNAL_KEYBOARD and QUEST_JOURNAL_KEYBOARD.GetIconTexture then
+        local ok, texture = pcall(QUEST_JOURNAL_KEYBOARD.GetIconTexture, QUEST_JOURNAL_KEYBOARD, displayType)
+        if ok and texture and texture ~= "" then
+            return texture
+        end
+    end
+    return "EsoUI/Art/Journal/journal_tabIcon_quests_up.dds"
+end
+
+local function formatQuestLabel(name, level)
+    local questName = sanitizeText(name)
+    if level and level > 0 then
+        return string.format("[%d] %s", level, questName)
+    end
+    return questName
+end
+
+local function questStepKey(questIndex, questId)
+    if type(GetJournalQuestNumSteps) ~= "function" then
+        return tostring(questId or questIndex or "")
+    end
+    local parts = {}
+    local steps = safeCall(GetJournalQuestNumSteps, questIndex) or 0
+    for stepIndex = 1, steps do
+        local okStep,
+            stepText,
+            visibility,
+            stepType,
+            trackerComplete,
+            _,
+            _,
+            stepOverride = pcall(GetJournalQuestStepInfo, questIndex, stepIndex)
+        if okStep and not trackerComplete then
+            local summary = stepOverride ~= "" and stepOverride or stepText or ""
+            summary = sanitizeText(summary)
+            if summary ~= "" then
+                parts[#parts + 1] = string.format("%d:%s", stepIndex, summary)
+            end
+        end
+    end
+    if #parts == 0 then
+        parts[#parts + 1] = "complete"
+    end
+    return string.format("%d:%s", questId or 0, table.concat(parts, "|"))
+end
+
+local function gatherTrackedQuestSet()
+    if type(GetTrackedQuestIndices) ~= "function" then
+        return nil
+    end
+    local ok, ... = pcall(GetTrackedQuestIndices)
+    if not ok then
+        return nil
+    end
+    local count = select("#", ...)
+    local values = { ... }
+    local set = {}
+    for index = 1, count do
+        local questIndex = values[index]
+        if type(questIndex) == "number" and questIndex > 0 then
+            set[questIndex] = true
+        end
+    end
+    if next(set) then
+        return set
+    end
+    return nil
+end
+
+local function isQuestTracked(questIndex, trackedLookup)
+    if trackedLookup and trackedLookup[questIndex] then
+        return true
+    end
+    local trackers = {
+        GetJournalQuestIsTracked,
+        GetIsQuestTracked,
+        GetIsJournalQuestTracked,
+    }
+    for _, fn in ipairs(trackers) do
+        if type(fn) == "function" then
+            local ok, tracked = pcall(fn, questIndex)
+            if ok and tracked ~= nil then
+                return tracked
+            end
+        end
+    end
+    if type(IsJournalQuestStepTracked) == "function" and type(GetJournalQuestNumSteps) == "function" then
+        local steps = safeCall(GetJournalQuestNumSteps, questIndex) or 0
+        for stepIndex = 1, steps do
+            local okStep, trackedStep = pcall(IsJournalQuestStepTracked, questIndex, stepIndex)
+            if okStep and trackedStep then
+                return true
+            end
+        end
+        return false
+    end
+    if trackedLookup then
+        return false
+    end
+    return true
+end
+
+local function buildQuestSteps(questIndex)
+    local stepEntries = {}
+    local summaries = {}
+    local seenSummaries = {}
+    local objectives = {}
+    local steps = safeCall(GetJournalQuestNumSteps, questIndex) or 0
+    for stepIndex = 1, steps do
+        local okStep,
+            stepText,
+            visibility,
+            stepType,
+            trackerComplete,
+            _,
+            _,
+            stepOverride = pcall(GetJournalQuestStepInfo, questIndex, stepIndex)
+        if okStep then
+            local hidden = (QUEST_STEP_VISIBILITY_HIDDEN and visibility == QUEST_STEP_VISIBILITY_HIDDEN)
+            if not hidden then
+                local summary = stepOverride ~= "" and stepOverride or stepText or ""
+                summary = sanitizeText(summary)
+                if summary ~= "" and not seenSummaries[summary] then
+                    summaries[#summaries + 1] = summary
+                    seenSummaries[summary] = true
+                end
+            end
+
+            local conditionEntries = {}
+            local numConditions = safeCall(GetJournalQuestNumConditions, questIndex, stepIndex) or 0
+            for conditionIndex = 1, numConditions do
+                local okCondition,
+                    conditionText,
+                    cur,
+                    max,
+                    isFail,
+                    isComplete = pcall(GetJournalQuestConditionInfo, questIndex, stepIndex, conditionIndex)
+                if okCondition then
+                    local visible = true
+                    if type(IsJournalQuestConditionVisible) == "function" then
+                        local okVisible, isVisible = pcall(IsJournalQuestConditionVisible, questIndex, stepIndex, conditionIndex)
+                        if okVisible then
+                            visible = isVisible
+                        end
+                    end
+                    if visible and conditionText ~= "" then
+                        local normalized = sanitizeText(conditionText)
+                        local conditionEntry = {
+                            text = normalized,
+                            current = cur,
+                            max = max,
+                            done = isComplete,
+                            isFail = isFail,
+                            stepIndex = stepIndex,
+                            conditionIndex = conditionIndex,
+                        }
+                        conditionEntries[#conditionEntries + 1] = conditionEntry
+                        if not isComplete and not isFail then
+                            objectives[#objectives + 1] = {
+                                text = normalized,
+                                current = cur,
+                                max = max,
+                                stepIndex = stepIndex,
+                                conditionIndex = conditionIndex,
+                            }
+                        end
+                    end
+                end
+            end
+
+            stepEntries[#stepEntries + 1] = {
+                index = stepIndex,
+                text = sanitizeText(stepOverride ~= "" and stepOverride or stepText or ""),
+                done = trackerComplete,
+                stepType = stepType,
+                trackerComplete = trackerComplete,
+                conditions = conditionEntries,
+            }
+        end
+    end
+    return stepEntries, summaries, objectives
+end
+
+local function buildCategoryLookup(allCategories)
+    local lookup = {}
+    for index, categoryData in ipairs(allCategories) do
+        local name = categoryData.name or ""
+        local sanitizedName = formatCategoryDisplayName(name)
+        local key = string.format("cat:%d:%d", categoryData.type or 0, index)
+        lookup[name] = {
+            key = key,
+            name = sanitizedName,
+            type = categoryData.type or 0,
+            orderIndex = index,
+        }
+    end
+    return lookup
+end
+
+local function ensureCategory(lookup, orderCounter, categoryName, categoryType)
+    local key = categoryName ~= "" and categoryName or "__general__"
+    local data = lookup[key]
+    if data then
+        return data, orderCounter
+    end
+    orderCounter = orderCounter + 1
+    data = {
+        key = string.format("cat:%d:%d", categoryType or 999, orderCounter),
+        name = formatCategoryDisplayName(categoryName ~= "" and categoryName or ""),
+        type = categoryType or 999,
+        orderIndex = orderCounter,
+    }
+    lookup[key] = data
+    return data, orderCounter
+end
+
+function Module.Scan()
+    Module.Quests = Module.Quests or { order = {}, byId = {}, categories = {} }
+    Module.Quests.order = {}
+    Module.Quests.byId = {}
+    Module.Quests.categories = {}
+
+    if not (QUEST_MANAGER and QUEST_MANAGER.GetQuestListData) then
+        debugLog("Quest journal manager unavailable")
+        return Module.Quests
+    end
+
+    local okData, allQuests, allCategories = pcall(QUEST_MANAGER.GetQuestListData, QUEST_MANAGER)
+    if not okData or type(allQuests) ~= "table" or type(allCategories) ~= "table" then
+        debugLog("Failed to retrieve quest list data")
+        return Module.Quests
+    end
+
+    local trackedLookup = gatherTrackedQuestSet()
+    local trackerSV = getTrackerSV()
+    local collapseLookup = trackerSV and trackerSV.collapseState and trackerSV.collapseState.quests or nil
+    local categoryLookup = buildCategoryLookup(allCategories)
+    local orderCounter = #allCategories
+
+    local GENERAL = formatCategoryDisplayName("")
+
+    for _, questData in ipairs(allQuests) do
+        local questIndex = questData.questIndex
+        if questIndex then
+            local isTrackedFlag = isQuestTracked(questIndex, trackedLookup)
+            local questId = questData.questId or safeCall(GetJournalQuestId, questIndex) or 0
+            local rawName = questData.name or questData.questName or ""
+            local questName = sanitizeText(rawName)
+            if questName == "" then
+                questName = sanitizeText(select(1, safeCall(GetJournalQuestName, questIndex)) or "")
+            end
+
+            local categoryName = questData.categoryName or GENERAL
+            local categoryType = questData.categoryType or 0
+            local categoryEntry, newCounter = ensureCategory(categoryLookup, orderCounter, categoryName, categoryType)
+            orderCounter = newCounter
+
+            local steps, summaries, objectives = buildQuestSteps(questIndex)
+            local stepText = summaries[1]
+            if not stepText or stepText == "" then
+                stepText = sanitizeText(
+                    questData.trackerOverrideText or questData.stepText or questData.conditionText or ""
+                )
+            end
+
+            local questKey = questStepKey(questIndex, questId)
+            local entry = {
+                id = questId,
+                questId = questId,
+                key = questKey,
+                journalIndex = questIndex,
+                title = questName,
+                name = questName,
+                displayName = formatQuestLabel(questName, questData.level),
+                zoneName = categoryEntry.name ~= "" and categoryEntry.name or GENERAL,
+                zoneKey = categoryEntry.key,
+                zoneType = categoryEntry.type,
+                zoneOrderIndex = categoryEntry.orderIndex,
+                zoneIcon = "EsoUI/Art/Journal/journal_tabIcon_locations_up.dds",
+                isComplete = questData.isComplete or false,
+                isTracked = isTrackedFlag == true,
+                isCollapsed = collapseLookup and collapseLookup[questKey] == true or false,
+                objectives = objectives,
+                steps = steps,
+                stepSummaries = summaries,
+                stepText = stepText,
+                icon = getQuestDisplayIcon(questData.displayType),
+                order = questData.sortOrder or questIndex,
+                level = questData.level,
+                displayType = questData.displayType,
+                updatedAt = GetFrameTimeMilliseconds and GetFrameTimeMilliseconds() or GetTimeStamp(),
+                priorityScore = questData.sortOrder or questIndex,
+            }
+
+            Module.Quests.byId[questKey] = entry
+            Module.Quests.order[#Module.Quests.order + 1] = questKey
+        end
+    end
+
+    return Module.Quests
+end
+
+function Module.GetList()
+    if not Module.Quests or not Module.Quests.order then
+        Module.Scan()
+    end
+    return Module.Quests.order or {}, Module.Quests.byId or {}
+end
+
+function Module.ForceRefresh()
+    if EM and EM.UnregisterForUpdate then
+        EM:UnregisterForUpdate(REFRESH_HANDLE)
+    end
+    Module.refreshPending = false
+    Module.dirty = false
+    Module.Scan()
+    if M.Publish then
+        M.Publish("quests:changed", Module.Quests)
+    elseif M.Core and M.Core.Publish then
+        M.Core.Publish("quests:changed", Module.Quests)
+    end
+end
+
+function Module.ThrottledRefresh()
+    if Module.refreshPending then
+        return
+    end
+    Module.refreshPending = true
+    local delay = DEFAULT_REFRESH_DELAY_MS
+    local trackerSV = M and M.sv and M.sv.tracker
+    if trackerSV and trackerSV.throttleMs then
+        delay = tonumber(trackerSV.throttleMs) or delay
+    end
+
+    local function callback()
+        Module.refreshPending = false
+        if Module.dirty then
+            Module.ForceRefresh()
+        end
+    end
+
+    if EM and EM.RegisterForUpdate then
+        EM:RegisterForUpdate(REFRESH_HANDLE, delay, function()
+            if EM.UnregisterForUpdate then
+                EM:UnregisterForUpdate(REFRESH_HANDLE)
+            end
+            callback()
+        end)
+    else
+        zo_callLater(callback, delay)
+    end
+end
+
+local function handleQuestUpdate()
+    Module.dirty = true
+    Module.ThrottledRefresh()
+end
+
+function Module.Init()
+    debugLog("Init() invoked")
+    Module.dirty = true
+    if not EM then
+        Module.ForceRefresh()
+        return
+    end
+
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_Activated", EVENT_PLAYER_ACTIVATED)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_Activated", EVENT_PLAYER_ACTIVATED, handleQuestUpdate)
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_QuestAdded", EVENT_QUEST_ADDED)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_QuestAdded", EVENT_QUEST_ADDED, handleQuestUpdate)
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_QuestRemoved", EVENT_QUEST_REMOVED)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_QuestRemoved", EVENT_QUEST_REMOVED, handleQuestUpdate)
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_QuestAdvanced", EVENT_QUEST_ADVANCED)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_QuestAdvanced", EVENT_QUEST_ADVANCED, handleQuestUpdate)
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_ConditionChanged", EVENT_QUEST_CONDITION_COUNTER_CHANGED)
+    EM:RegisterForEvent(
+        "Nvk3UT_QuestModel_ConditionChanged",
+        EVENT_QUEST_CONDITION_COUNTER_CHANGED,
+        handleQuestUpdate
+    )
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_PlayerCombat", EVENT_PLAYER_COMBAT_STATE)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_PlayerCombat", EVENT_PLAYER_COMBAT_STATE, function()
+        handleQuestUpdate()
+    end)
+    EM:UnregisterForEvent("Nvk3UT_QuestModel_ObjectiveCompleted", EVENT_OBJECTIVE_COMPLETED)
+    EM:RegisterForEvent("Nvk3UT_QuestModel_ObjectiveCompleted", EVENT_OBJECTIVE_COMPLETED, handleQuestUpdate)
+
+    Module.ForceRefresh()
+end
+
+function Module.SetTracked(questKey, shouldTrack)
+    if not questKey then
+        return
+    end
+
+    local quests = Module.Quests or {}
+    local quest = quests.byId and quests.byId[questKey]
+    if not quest then
+        return
+    end
+
+    if shouldTrack == nil then
+        shouldTrack = not (quest.isTracked ~= false)
+    end
+
+    quest.isTracked = shouldTrack and true or false
+
+    local journalIndex = quest.journalIndex
+    if journalIndex then
+        local applied = false
+        if QUEST_MANAGER and QUEST_MANAGER.SetQuestIsTracked then
+            local ok = pcall(QUEST_MANAGER.SetQuestIsTracked, QUEST_MANAGER, journalIndex, shouldTrack)
+            applied = applied or ok
+        end
+        if type(SetTrackedIsTracked) == "function" then
+            local ok = pcall(SetTrackedIsTracked, journalIndex, shouldTrack)
+            applied = applied or ok
+        end
+        if shouldTrack and type(SetTrackedQuestIndex) == "function" then
+            pcall(SetTrackedQuestIndex, journalIndex)
+        end
+        if not applied and QUEST_MANAGER and QUEST_MANAGER.SetQuestStepIsTracked and type(quest.steps) == "table" then
+            for _, step in ipairs(quest.steps) do
+                if step.index then
+                    pcall(QUEST_MANAGER.SetQuestStepIsTracked, QUEST_MANAGER, journalIndex, step.index, shouldTrack)
+                end
+            end
+        end
+    end
+
+    Module.ForceRefresh()
+end
+
+return

--- a/Nvk3UT_Questtracker.xml
+++ b/Nvk3UT_Questtracker.xml
@@ -1,0 +1,53 @@
+<GuiXml>
+    <Controls>
+        <Control name="Nvk3UT_TrackerRootTemplate" virtual="true" />
+        <Control name="Nvk3UT_RowQuestTitleTemplate" virtual="true">
+            <Dimensions x="0" y="32" />
+            <Controls>
+                <Texture name="$(parent)Caret" textureFile="EsoUI/Art/Buttons/tree_open_up.dds" pixelRoundingEnabled="false">
+                    <Dimensions x="18" y="18" />
+                    <Anchor point="LEFT" offsetX="6" />
+                </Texture>
+                <Label name="$(parent)Label" font="ZoFontGameBold" horizontalAlignment="LEFT" verticalAlignment="CENTER">
+                    <Anchor point="TOPLEFT" relativeTo="$(parent)Caret" relativePoint="TOPRIGHT" offsetX="8" offsetY="0" />
+                    <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Progress" relativePoint="BOTTOMLEFT" offsetX="-8" offsetY="0" />
+                </Label>
+                <Label name="$(parent)Progress" font="ZoFontGame" horizontalAlignment="RIGHT" verticalAlignment="CENTER">
+                    <Anchor point="RIGHT" offsetX="-8" />
+                </Label>
+            </Controls>
+        </Control>
+        <Control name="Nvk3UT_RowQuestStepTemplate" virtual="true">
+            <Dimensions x="0" y="24" />
+            <Controls>
+                <Label name="$(parent)Label" font="ZoFontGame" horizontalAlignment="LEFT" verticalAlignment="CENTER">
+                    <Anchor point="TOPLEFT" offsetX="24" offsetY="0" />
+                    <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Progress" relativePoint="BOTTOMLEFT" offsetX="-8" offsetY="0" />
+                </Label>
+                <Label name="$(parent)Progress" font="ZoFontGame" horizontalAlignment="RIGHT" verticalAlignment="CENTER">
+                    <Anchor point="RIGHT" offsetX="-8" />
+                </Label>
+            </Controls>
+        </Control>
+        <Control name="Nvk3UT_RowDividerTemplate" virtual="true">
+            <Dimensions x="0" y="2" />
+            <Controls>
+                <Texture name="$(parent)Line" color="FFFFFFFF">
+                    <AnchorFill />
+                </Texture>
+            </Controls>
+        </Control>
+        <Control name="Nvk3UT_RowAchievementTemplate" virtual="true">
+            <Dimensions x="0" y="32" />
+            <Controls>
+                <Label name="$(parent)Label" font="ZoFontGameBold" horizontalAlignment="LEFT" verticalAlignment="CENTER">
+                    <Anchor point="TOPLEFT" offsetX="8" offsetY="0" />
+                    <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Progress" relativePoint="BOTTOMLEFT" offsetX="-8" offsetY="0" />
+                </Label>
+                <Label name="$(parent)Progress" font="ZoFontGame" horizontalAlignment="RIGHT" verticalAlignment="CENTER">
+                    <Anchor point="RIGHT" offsetX="-8" />
+                </Label>
+            </Controls>
+        </Control>
+    </Controls>
+</GuiXml>

--- a/Nvk3UT_Tracker.lua
+++ b/Nvk3UT_Tracker.lua
@@ -1,0 +1,475 @@
+Nvk3UT = Nvk3UT or {}
+local M = Nvk3UT
+
+M.Tracker = M.Tracker or {}
+local Module = M.Tracker
+
+local EM = EVENT_MANAGER
+
+local DEFAULT_TRACKER_REASON = "Nvk3UT_Tracker"
+local DEFAULT_TRACKER_FRAGMENTS = {
+    "FOCUSED_QUEST_TRACKER_FRAGMENT",
+    "FOCUSED_QUEST_TRACKER_ALWAYS_SHOW_FRAGMENT",
+    "FOCUSED_QUEST_TRACKER_TRACKED_FRAGMENT",
+    "FOCUSED_QUEST_TRACKER_FOCUSED_FRAGMENT",
+    "GAMEPAD_QUEST_TRACKER_FRAGMENT",
+}
+
+local function debugLog(message)
+    if d then
+        d(string.format("[Nvk3UT] Tracker: %s", tostring(message)))
+    end
+end
+
+local function getRootSV()
+    return M and M.sv
+end
+
+local function ensureSettings()
+    local root = getRootSV()
+    if not root then
+        return nil
+    end
+    root.settings = root.settings or {}
+    root.settings.quest = root.settings.quest or {}
+    root.settings.ach = root.settings.ach or {}
+    root.settings.tracker = root.settings.tracker or {}
+    return root.settings
+end
+
+local function getTrackerSV()
+    local root = getRootSV()
+    if not root then
+        return nil
+    end
+    root.tracker = root.tracker or {}
+    local sv = root.tracker
+    sv.behavior = sv.behavior or {}
+    sv.background = sv.background or {}
+    sv.fonts = sv.fonts or {}
+    sv.pos = sv.pos or {}
+    sv.collapseState = sv.collapseState or { zones = {}, quests = {}, achieves = {} }
+    return sv
+end
+
+local function getQuestSettings()
+    local settings = ensureSettings()
+    return settings and settings.quest or {}
+end
+
+local function getAchSettings()
+    local settings = ensureSettings()
+    return settings and settings.ach or {}
+end
+
+local function getTrackerSettings()
+    local settings = ensureSettings()
+    return settings and settings.tracker or {}
+end
+
+local function publishSettingsChanged(key)
+    if M and M.Publish then
+        M.Publish("settings:changed", key)
+    elseif M and M.Core and M.Core.Publish then
+        M.Core.Publish("settings:changed", key)
+    end
+end
+
+local function markViewDirty()
+    if M and M.TrackerView and M.TrackerView.MarkDirty then
+        M.TrackerView.MarkDirty()
+    end
+end
+
+local function applyViewSettings()
+    if M and M.TrackerView and M.TrackerView.ApplySettingsFromSV then
+        M.TrackerView.ApplySettingsFromSV()
+    end
+end
+
+local function applyLockState()
+    if M and M.TrackerView and M.TrackerView.ApplyLockState then
+        M.TrackerView.ApplyLockState()
+    end
+end
+
+local function applyBackground()
+    if M and M.TrackerView and M.TrackerView.ApplyBackground then
+        M.TrackerView.ApplyBackground()
+    end
+end
+
+local function applyScale()
+    if M and M.TrackerView and M.TrackerView.ApplyScaleFromSettings then
+        M.TrackerView.ApplyScaleFromSettings()
+    end
+end
+
+local function setDefaultTrackerHidden(hidden)
+    for _, fragmentName in ipairs(DEFAULT_TRACKER_FRAGMENTS) do
+        local fragment = _G and _G[fragmentName]
+        if fragment and fragment.SetHiddenForReason then
+            fragment:SetHiddenForReason(DEFAULT_TRACKER_REASON, hidden)
+        end
+    end
+
+    local focusedTracker = _G and _G.FOCUSED_QUEST_TRACKER
+    if focusedTracker then
+        if focusedTracker.SetHiddenForReason then
+            focusedTracker.SetHiddenForReason(DEFAULT_TRACKER_REASON, hidden)
+        elseif focusedTracker.SetHidden then
+            focusedTracker:SetHidden(hidden)
+        end
+        local control = focusedTracker.control
+        if control and control.SetHidden then
+            control:SetHidden(hidden)
+        end
+    end
+end
+
+local function updateDefaultTrackerVisibility()
+    local settings = getTrackerSettings()
+    local hideDefault = settings and settings.hideDefault == true
+    setDefaultTrackerHidden(hideDefault)
+end
+
+function Module.ApplyDefaultTrackerVisibility()
+    updateDefaultTrackerVisibility()
+end
+
+local function isEnabled()
+    local sv = getTrackerSV()
+    if not sv then
+        return true
+    end
+    if sv.enabled == nil then
+        return true
+    end
+    return sv.enabled
+end
+
+function Module.IsCombatHidden()
+    if not Module.inCombat then
+        return false
+    end
+    local settings = getTrackerSettings()
+    return settings and settings.hideInCombat == true
+end
+
+function Module.ShouldHideTracker()
+    if not isEnabled() then
+        return true
+    end
+    if Module.IsCombatHidden() then
+        return true
+    end
+    return false
+end
+
+local function updateRootHidden()
+    if M and M.TrackerView and M.TrackerView.GetRootControl then
+        local root = M.TrackerView.GetRootControl()
+        if root then
+            root:SetHidden(Module.ShouldHideTracker())
+        end
+    end
+end
+
+local function notifyQuestSection()
+    publishSettingsChanged("quest.enabled")
+end
+
+local function notifyAchSection()
+    publishSettingsChanged("ach.enabled")
+end
+
+function Module.SetEnabled(value)
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+    local flag = value == true
+    if sv.enabled == flag then
+        return
+    end
+    sv.enabled = flag
+    publishSettingsChanged("tracker.enabled")
+    updateRootHidden()
+end
+
+function Module.RegisterLamPanel(panelControl)
+    Module.lamPanelControl = panelControl
+end
+
+function Module.GetSavedVars()
+    return getTrackerSV()
+end
+
+function Module.SetShowQuests(value)
+    local settings = getQuestSettings()
+    local flag = value == true
+    if settings.enabled == flag then
+        return
+    end
+    settings.enabled = flag
+    local sv = getTrackerSV()
+    if sv then
+        sv.showQuests = flag
+    end
+    notifyQuestSection()
+    markViewDirty()
+end
+
+function Module.SetShowAchievements(value)
+    local settings = getAchSettings()
+    local flag = value == true
+    if settings.enabled == flag then
+        return
+    end
+    settings.enabled = flag
+    local sv = getTrackerSV()
+    if sv then
+        sv.showAchievements = flag
+    end
+    notifyAchSection()
+    markViewDirty()
+end
+
+local function setTrackerBehavior(key, value)
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+    sv.behavior = sv.behavior or {}
+    if sv.behavior[key] == value then
+        return
+    end
+    sv.behavior[key] = value
+end
+
+local function setTrackerSetting(key, value)
+    local settings = getTrackerSettings()
+    if not settings then
+        return
+    end
+    if settings[key] == value then
+        return
+    end
+    settings[key] = value
+    publishSettingsChanged("tracker." .. key)
+end
+
+function Module.SetBehaviorOption(key, value)
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+
+    if key == "autoExpandNewQuests" then
+        local questSettings = getQuestSettings()
+        local flag = value == true
+        if questSettings.autoExpandNew ~= flag then
+            questSettings.autoExpandNew = flag
+            publishSettingsChanged("quest.autoExpandNew")
+        end
+        sv.behavior[key] = flag
+        return
+    end
+
+    if key == "alwaysExpandAchievements" then
+        local achSettings = getAchSettings()
+        local flag = value == true
+        if achSettings.alwaysExpand ~= flag then
+            achSettings.alwaysExpand = flag
+            publishSettingsChanged("ach.alwaysExpand")
+        end
+        sv.behavior[key] = flag
+        return
+    end
+
+    if key == "tooltips" then
+        local questSettings = getQuestSettings()
+        local achSettings = getAchSettings()
+        local enabled = value ~= false
+        if questSettings.tooltips ~= enabled then
+            questSettings.tooltips = enabled
+            publishSettingsChanged("quest.tooltips")
+        end
+        if achSettings.tooltips ~= enabled then
+            achSettings.tooltips = enabled
+            publishSettingsChanged("ach.tooltips")
+        end
+        sv.behavior[key] = enabled
+        return
+    end
+
+    if key == "hideDefault" then
+        setTrackerSetting("hideDefault", value == true)
+        sv.behavior[key] = value == true
+        updateDefaultTrackerVisibility()
+        return
+    end
+
+    if key == "hideInCombat" then
+        setTrackerSetting("hideInCombat", value == true)
+        sv.behavior[key] = value == true
+        updateRootHidden()
+        return
+    end
+
+    if key == "locked" then
+        setTrackerSetting("locked", value == true)
+        sv.behavior[key] = value == true
+        applyLockState()
+        return
+    end
+
+    if key == "autoGrowV" or key == "autoGrowH" then
+        setTrackerBehavior(key, value == true)
+        publishSettingsChanged("tracker." .. key)
+        applyViewSettings()
+        return
+    end
+
+    setTrackerBehavior(key, value)
+    publishSettingsChanged("tracker.behavior." .. key)
+    applyViewSettings()
+end
+
+function Module.SetThrottle(value)
+    local numeric = tonumber(value)
+    if not numeric then
+        return
+    end
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+    if sv.throttleMs == numeric then
+        return
+    end
+    sv.throttleMs = numeric
+    publishSettingsChanged("tracker.throttle")
+end
+
+function Module.SetBackgroundOption(key, value)
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+    sv.background = sv.background or {}
+    if sv.background[key] == value then
+        return
+    end
+    sv.background[key] = value
+    publishSettingsChanged("tracker.background." .. tostring(key))
+    applyBackground()
+end
+
+local function ensureFontSection(section)
+    local sv = getTrackerSV()
+    if not sv then
+        return nil
+    end
+    sv.fonts = sv.fonts or {}
+    sv.fonts[section] = sv.fonts[section] or {}
+    return sv.fonts[section]
+end
+
+function Module.SetFontOption(section, field, value)
+    if type(section) ~= "string" or type(field) ~= "string" then
+        return
+    end
+    local fontSection = ensureFontSection(section)
+    if not fontSection then
+        return
+    end
+    if fontSection[field] == value then
+        return
+    end
+    fontSection[field] = value
+    publishSettingsChanged("tracker.font." .. section .. "." .. field)
+    markViewDirty()
+end
+
+function Module.SetFontColor(section, r, g, b, a)
+    if type(section) ~= "string" then
+        return
+    end
+    local fontSection = ensureFontSection(section)
+    if not fontSection then
+        return
+    end
+    fontSection.color = fontSection.color or {}
+    fontSection.color.r = r
+    fontSection.color.g = g
+    fontSection.color.b = b
+    fontSection.color.a = a
+    publishSettingsChanged("tracker.fontColor." .. section)
+    markViewDirty()
+end
+
+function Module.SetScale(scale)
+    local numeric = tonumber(scale)
+    if not numeric then
+        return
+    end
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+    sv.pos = sv.pos or {}
+    if sv.pos.scale == numeric then
+        return
+    end
+    sv.pos.scale = numeric
+    applyScale()
+end
+
+function Module.ForceRefresh()
+    if M and M.TrackerView and M.TrackerView.ForceRefresh then
+        M.TrackerView.ForceRefresh()
+    else
+        markViewDirty()
+    end
+end
+
+function Module.MarkDirty()
+    markViewDirty()
+end
+
+function Module.NotifyViewReady()
+    updateDefaultTrackerVisibility()
+    updateRootHidden()
+    applyViewSettings()
+    markViewDirty()
+end
+
+local function onCombatState(_, inCombat)
+    Module.inCombat = inCombat == true
+    updateRootHidden()
+end
+
+function Module.Init()
+    getTrackerSV()
+    ensureSettings()
+
+    if EM and EM.RegisterForEvent then
+        EM:UnregisterForEvent("Nvk3UT_Tracker_Combat", EVENT_PLAYER_COMBAT_STATE)
+        EM:RegisterForEvent("Nvk3UT_Tracker_Combat", EVENT_PLAYER_COMBAT_STATE, onCombatState)
+    end
+
+    if type(IsUnitInCombat) == "function" then
+        local ok, state = pcall(IsUnitInCombat, "player")
+        Module.inCombat = ok and state == true
+    else
+        Module.inCombat = false
+    end
+
+    updateDefaultTrackerVisibility()
+    updateRootHidden()
+    Module.initialized = true
+    debugLog("Init() complete")
+end
+
+return

--- a/Nvk3UT_TrackerView.lua
+++ b/Nvk3UT_TrackerView.lua
@@ -1,0 +1,1223 @@
+Nvk3UT = Nvk3UT or {}
+local M = Nvk3UT
+
+M.TrackerView = M.TrackerView or {}
+local Module = M.TrackerView
+
+M.QuestSection = M.QuestSection or {}
+local QuestSection = M.QuestSection
+
+M.AchSection = M.AchSection or {}
+local AchSection = M.AchSection
+
+local WM = WINDOW_MANAGER
+local EM = EVENT_MANAGER
+local GuiRoot = GuiRoot
+local SCENE_MANAGER = SCENE_MANAGER
+
+local LIST_CONTROL_NAME = "Nvk3UT_TrackerList"
+local ROOT_CONTROL_NAME = "Nvk3UT_TrackerRoot"
+local REFRESH_HANDLE = "Nvk3UT_TrackerViewRefresh"
+local DEFAULT_REFRESH_DELAY_MS = 100
+local DIVIDER_DATA_TYPE = 9000
+local DIVIDER_ROW_HEIGHT = 2
+local MIN_WIDTH = 260
+local MIN_HEIGHT = 220
+local PADDING_X = 12
+local PADDING_Y = 12
+local TRACKER_SCENES = { "hud", "hudui" }
+local LEFT_BUTTON = (_G and _G.MOUSE_BUTTON_INDEX_LEFT) or MOUSE_BUTTON_INDEX_LEFT or 1
+
+local CARET_TEXTURE_OPEN = "EsoUI/Art/Buttons/tree_open_up.dds"
+local CARET_TEXTURE_CLOSED = "EsoUI/Art/Buttons/tree_closed_up.dds"
+
+local DEFAULT_FONTS = {
+    quest = { face = "ZoFontGameBold", size = 20, effect = "soft-shadow-thin" },
+    task = { face = "ZoFontGame", size = 18, effect = "soft-shadow-thin" },
+    achieve = { face = "ZoFontGameBold", size = 20, effect = "soft-shadow-thin" },
+    achieveTask = { face = "ZoFontGame", size = 18, effect = "soft-shadow-thin" },
+}
+
+local DEFAULT_COLORS = {
+    quest = { r = 1, g = 0.82, b = 0.1, a = 1 },
+    task = { r = 0.9, g = 0.9, b = 0.9, a = 1 },
+    achieve = { r = 1, g = 0.82, b = 0.1, a = 1 },
+    achieveTask = { r = 0.9, g = 0.9, b = 0.9, a = 1 },
+}
+
+local function debugLog(message)
+    if d then
+        d(string.format("[Nvk3UT] TrackerView: %s", tostring(message)))
+    end
+end
+
+local function getTrackerSV()
+    local root = M and M.sv and M.sv.tracker
+    if not root then
+        return nil
+    end
+
+    root.behavior = root.behavior or {}
+    root.background = root.background or {}
+    root.fonts = root.fonts or {}
+    root.pos = root.pos or {}
+    root.collapseState = root.collapseState or { zones = {}, quests = {}, achieves = {} }
+
+    return root
+end
+
+local function getSettingsNamespace(key)
+    local sv = M and M.sv and M.sv.settings
+    if not sv then
+        return nil
+    end
+    sv[key] = sv[key] or {}
+    return sv[key]
+end
+
+local function getQuestSettings()
+    return getSettingsNamespace("quest") or {}
+end
+
+local function getAchievementSettings()
+    return getSettingsNamespace("ach") or {}
+end
+
+local function getTrackerSettings()
+    return getSettingsNamespace("tracker") or {}
+end
+
+local function buildFontString(config, defaults)
+    local face = defaults.face
+    if config and type(config.face) == "string" and config.face ~= "" then
+        face = config.face
+    end
+
+    local size = tonumber(defaults.size) or 18
+    if config and tonumber(config.size) then
+        size = tonumber(config.size)
+    end
+
+    local effect = defaults.effect or "none"
+    if config and type(config.effect) == "string" and config.effect ~= "" then
+        effect = config.effect
+    end
+
+    return string.format("%s|%d|%s", face, size, effect)
+end
+
+local function resolveColor(config, defaults)
+    local source = defaults
+    if config and type(config.color) == "table" then
+        source = config.color
+    end
+
+    local r = tonumber(source.r) or defaults.r or 1
+    local g = tonumber(source.g) or defaults.g or 1
+    local b = tonumber(source.b) or defaults.b or 1
+    local a = tonumber(source.a) or defaults.a or 1
+    return r, g, b, a
+end
+
+local function applyFontAndColor(label, section)
+    if not label or not section then
+        return
+    end
+
+    local sv = getTrackerSV()
+    local fonts = (sv and sv.fonts) or {}
+    local config = fonts[section]
+    local defaults = DEFAULT_FONTS[section] or DEFAULT_FONTS.task
+    local fontString = buildFontString(config, defaults)
+    label:SetFont(fontString)
+
+    local defaultColor = DEFAULT_COLORS[section] or DEFAULT_COLORS.task
+    local r, g, b, a = resolveColor(config, defaultColor)
+    label:SetColor(r, g, b, a)
+end
+
+local function beginTooltip()
+    local questSettings = getQuestSettings()
+    local achSettings = getAchievementSettings()
+    if Module.activeTooltipNamespace == "quest" and questSettings.tooltips == false then
+        return false
+    end
+    if Module.activeTooltipNamespace == "ach" and achSettings.tooltips == false then
+        return false
+    end
+    if not Module.rootControl or not InformationTooltip then
+        return false
+    end
+    InitializeTooltip(InformationTooltip, Module.rootControl, LEFT, -16, 0, RIGHT)
+    InformationTooltip:ClearLines()
+    return true
+end
+
+function Module.ShowTooltip(namespace, buildFn)
+    Module.activeTooltipNamespace = namespace
+    if not beginTooltip() then
+        Module.activeTooltipNamespace = nil
+        return
+    end
+    if type(buildFn) == "function" then
+        buildFn(InformationTooltip)
+    end
+end
+
+function Module.HideTooltip()
+    Module.activeTooltipNamespace = nil
+    if InformationTooltip then
+        ClearTooltip(InformationTooltip)
+    end
+end
+
+local function shouldHideInCombat()
+    local trackerSettings = getTrackerSettings()
+    if trackerSettings and trackerSettings.hideInCombat then
+        local tracker = M and M.Tracker
+        if tracker and tracker.IsCombatHidden then
+            return tracker.IsCombatHidden()
+        end
+    end
+    return false
+end
+
+local function savePosition()
+    if not Module.rootControl then
+        return
+    end
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+
+    local pos = sv.pos
+    pos.x = math.floor(Module.rootControl:GetLeft())
+    pos.y = math.floor(Module.rootControl:GetTop())
+end
+
+local function saveDimensions()
+    if not Module.rootControl then
+        return
+    end
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+
+    local behavior = (sv.behavior or {})
+    if behavior.autoGrowV then
+        return
+    end
+
+    sv.pos.width = math.max(MIN_WIDTH, Module.rootControl:GetWidth())
+    sv.pos.height = math.max(MIN_HEIGHT, Module.rootControl:GetHeight())
+end
+
+local function applyLockState()
+    if not Module.rootControl then
+        return
+    end
+    local trackerSettings = getTrackerSettings()
+    local locked = trackerSettings and trackerSettings.locked == true
+    Module.rootControl:SetMovable(not locked)
+    Module.rootControl:SetMouseEnabled(true)
+    Module.rootControl:SetResizeHandleSize(locked and 0 or 8)
+end
+
+local function applyScaleAndPosition()
+    if not Module.rootControl then
+        return
+    end
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+
+    local pos = sv.pos or {}
+    Module.rootControl:SetScale(tonumber(pos.scale) or 1)
+    Module.rootControl:ClearAnchors()
+    Module.rootControl:SetAnchor(TOPLEFT, GuiRoot, TOPLEFT, tonumber(pos.x) or 400, tonumber(pos.y) or 200)
+
+    local width = math.max(MIN_WIDTH, tonumber(pos.width) or MIN_WIDTH)
+    local height = math.max(MIN_HEIGHT, tonumber(pos.height) or MIN_HEIGHT)
+    Module.rootControl:SetDimensions(width, height)
+end
+
+local function applyBackground()
+    if not Module.backdrop then
+        return
+    end
+
+    local sv = getTrackerSV()
+    local background = sv and sv.background or {}
+    local trackerSettings = getTrackerSettings() or {}
+
+    if not background.enabled or (background.hideWhenLocked and trackerSettings.locked) then
+        Module.backdrop:SetHidden(true)
+        return
+    end
+
+    local alpha = tonumber(background.alpha) or 60
+    local normalized = math.max(0, math.min(100, alpha)) / 100
+    Module.backdrop:SetCenterColor(0, 0, 0, normalized)
+    if background.border then
+        Module.backdrop:SetEdgeTexture(nil, 1, 1, 1, 1)
+        Module.backdrop:SetEdgeColor(1, 1, 1, normalized)
+    else
+        Module.backdrop:SetEdgeTexture(nil, 1, 1, 0, 0)
+        Module.backdrop:SetEdgeColor(0, 0, 0, 0)
+    end
+    Module.backdrop:SetHidden(false)
+end
+
+local function applyAutoSize()
+    if not Module.scrollList or not Module.rootControl then
+        return
+    end
+
+    local sv = getTrackerSV()
+    if not sv then
+        return
+    end
+
+    local behavior = sv.behavior or {}
+    if not behavior.autoGrowH and not behavior.autoGrowV then
+        return
+    end
+
+    local scrollControl = ZO_ScrollList_GetScrollControl(Module.scrollList)
+    local contentWidth = scrollControl and scrollControl:GetWidth() or Module.rootControl:GetWidth()
+    local contentHeight = scrollControl and scrollControl:GetHeight() or Module.rootControl:GetHeight()
+
+    local width = math.max(MIN_WIDTH, tonumber(sv.pos.width) or MIN_WIDTH)
+    local height = math.max(MIN_HEIGHT, tonumber(sv.pos.height) or MIN_HEIGHT)
+
+    if behavior.autoGrowH then
+        width = math.max(MIN_WIDTH, contentWidth + (PADDING_X * 2))
+        sv.pos.width = width
+    end
+
+    if behavior.autoGrowV then
+        height = math.max(MIN_HEIGHT, contentHeight + (PADDING_Y * 2))
+        sv.pos.height = height
+    end
+
+    Module.rootControl:SetDimensions(width, height)
+end
+
+local function shouldHideTracker()
+    local tracker = M and M.Tracker
+    if tracker and tracker.ShouldHideTracker then
+        return tracker.ShouldHideTracker()
+    end
+    if shouldHideInCombat() then
+        return true
+    end
+    return false
+end
+
+local function applyRootHiddenState()
+    if not Module.rootControl then
+        return
+    end
+    Module.rootControl:SetHidden(shouldHideTracker())
+end
+
+local function getQuestCollapseTable()
+    local sv = getTrackerSV()
+    if not sv then
+        return {}
+    end
+    sv.collapseState = sv.collapseState or {}
+    sv.collapseState.quests = sv.collapseState.quests or {}
+    return sv.collapseState.quests
+end
+
+local function scheduleRefresh()
+    if Module.refreshPending then
+        return
+    end
+
+    Module.refreshPending = true
+    local delay = DEFAULT_REFRESH_DELAY_MS
+    local sv = getTrackerSV()
+    if sv and sv.throttleMs then
+        delay = tonumber(sv.throttleMs) or delay
+    end
+
+    if EM and EM.RegisterForUpdate then
+        EM:RegisterForUpdate(REFRESH_HANDLE, delay, function()
+            if EM.UnregisterForUpdate then
+                EM:UnregisterForUpdate(REFRESH_HANDLE)
+            end
+            Module.RefreshNow()
+        end)
+    else
+        zo_callLater(Module.RefreshNow, delay)
+    end
+end
+
+local function registerDividerDataType()
+    if not Module.scrollList then
+        return
+    end
+
+    ZO_ScrollList_AddDataType(
+        Module.scrollList,
+        DIVIDER_DATA_TYPE,
+        "Nvk3UT_RowDividerTemplate",
+        DIVIDER_ROW_HEIGHT,
+        function(control)
+            if not control.line then
+                control.line = control:GetNamedChild("Line")
+                if control.line then
+                    control.line:SetColor(1, 1, 1, 0.1)
+                end
+            end
+        end
+    )
+end
+
+---------------------------------------------------------------------
+-- Quest Section
+---------------------------------------------------------------------
+
+QuestSection.dataTypes = {
+    TITLE = 9101,
+    STEP = 9102,
+}
+
+function QuestSection:Init(listControl)
+    self.listControl = listControl
+    self.dirty = true
+    self.knownKeys = {}
+    self.subscriptions = {}
+
+    local subscribe = M.Subscribe or (M.Core and M.Core.Subscribe)
+    if subscribe then
+        local questsChanged = subscribe("quests:changed", function()
+            self:HandleEvent("quests:changed")
+        end)
+        table.insert(self.subscriptions, { topic = "quests:changed", fn = questsChanged })
+
+        local settingsChanged = subscribe("settings:changed", function(key)
+            self:OnSettingsChanged(key)
+        end)
+        table.insert(self.subscriptions, { topic = "settings:changed", fn = settingsChanged })
+    end
+end
+
+function QuestSection:RegisterRowTypes(listControl)
+    ZO_ScrollList_AddDataType(
+        listControl,
+        self.dataTypes.TITLE,
+        "Nvk3UT_RowQuestTitleTemplate",
+        32,
+        function(control, data)
+            self:SetupQuestTitleRow(control, data)
+        end,
+        nil,
+        nil,
+        nil,
+        function(control)
+            control.data = nil
+            Module.HideTooltip()
+        end
+    )
+
+    ZO_ScrollList_AddDataType(
+        listControl,
+        self.dataTypes.STEP,
+        "Nvk3UT_RowQuestStepTemplate",
+        24,
+        function(control, data)
+            self:SetupQuestStepRow(control, data)
+        end,
+        nil,
+        nil,
+        nil,
+        function(control)
+            control.data = nil
+            Module.HideTooltip()
+        end
+    )
+end
+
+function QuestSection:OnSettingsChanged(key)
+    if type(key) ~= "string" then
+        return
+    end
+    if not key:match("^quest%.") then
+        return
+    end
+    self.dirty = true
+    Module.MarkDirty()
+end
+
+function QuestSection:HandleEvent(topic)
+    if topic ~= "quests:changed" then
+        return
+    end
+    self.dirty = true
+
+    local order, byId = M.QuestModel and M.QuestModel.GetList and M.QuestModel.GetList()
+    if type(order) ~= "table" or type(byId) ~= "table" then
+        Module.MarkDirty()
+        return
+    end
+
+    local known = self.knownKeys or {}
+    local collapse = getQuestCollapseTable()
+    local settings = getQuestSettings()
+    local autoExpand = settings.autoExpandNew == true
+
+    local newKeys = {}
+    for _, questKey in ipairs(order) do
+        newKeys[questKey] = true
+        if autoExpand and not known[questKey] then
+            collapse[questKey] = nil
+        end
+    end
+
+    for key in pairs(known) do
+        if not newKeys[key] then
+            known[key] = nil
+        end
+    end
+
+    for key in pairs(newKeys) do
+        known[key] = true
+    end
+
+    Module.MarkDirty()
+end
+
+function QuestSection:IsVisible()
+    local settings = getQuestSettings()
+    if settings.enabled == false then
+        return false
+    end
+
+    if shouldHideInCombat() then
+        return false
+    end
+
+    return true
+end
+
+function QuestSection:IsDirty()
+    return self.dirty == true
+end
+
+function QuestSection:ClearDirty()
+    self.dirty = false
+end
+
+function QuestSection:GetCollapseLookup()
+    return getQuestCollapseTable()
+end
+
+function QuestSection:BuildFeed()
+    local feed = {}
+    if not self:IsVisible() then
+        return feed
+    end
+
+    local order, byId = M.QuestModel and M.QuestModel.GetList and M.QuestModel.GetList()
+    if type(order) ~= "table" or type(byId) ~= "table" then
+        return feed
+    end
+
+    local collapse = self:GetCollapseLookup()
+
+    for _, questKey in ipairs(order) do
+        local quest = byId[questKey]
+        if quest then
+            local isCollapsed = collapse[questKey] == true
+            feed[#feed + 1] = {
+                dataType = self.dataTypes.TITLE,
+                questKey = questKey,
+                quest = quest,
+                collapsed = isCollapsed,
+            }
+
+            if not isCollapsed then
+                local objectives = quest.objectives or {}
+                if #objectives > 0 then
+                    for _, objective in ipairs(objectives) do
+                        feed[#feed + 1] = {
+                            dataType = self.dataTypes.STEP,
+                            questKey = questKey,
+                            quest = quest,
+                            objective = objective,
+                        }
+                    end
+                else
+                    local steps = quest.steps or {}
+                    for _, step in ipairs(steps) do
+                        if step.text and step.text ~= "" then
+                            feed[#feed + 1] = {
+                                dataType = self.dataTypes.STEP,
+                                questKey = questKey,
+                                quest = quest,
+                                text = step.text,
+                            }
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return feed
+end
+
+function QuestSection:ToggleCollapsed(questKey)
+    if not questKey then
+        return
+    end
+    local collapse = self:GetCollapseLookup()
+    local current = collapse[questKey] == true
+    if current then
+        collapse[questKey] = nil
+    else
+        collapse[questKey] = true
+    end
+    self.dirty = true
+    Module.MarkDirty()
+end
+
+local function questProgressText(quest)
+    if not quest or not quest.objectives then
+        return ""
+    end
+    local totalCurrent = 0
+    local totalMax = 0
+    for _, objective in ipairs(quest.objectives) do
+        local maxValue = tonumber(objective.max) or 0
+        if maxValue > 0 then
+            local currentValue = tonumber(objective.current) or 0
+            currentValue = math.max(0, math.min(maxValue, currentValue))
+            totalCurrent = totalCurrent + currentValue
+            totalMax = totalMax + maxValue
+        end
+    end
+    if totalMax > 0 then
+        return string.format("%d/%d", totalCurrent, totalMax)
+    end
+    return ""
+end
+
+function QuestSection:SetupQuestTitleRow(control, data)
+    control.data = data
+    control:SetMouseEnabled(true)
+
+    if not control.caret then
+        control.caret = control:GetNamedChild("Caret")
+        if not control.caret then
+            control.caret = WM:CreateControl(nil, control, CT_TEXTURE)
+            control.caret:SetAnchor(LEFT, control, LEFT, 0, 0)
+            control.caret:SetDimensions(16, 16)
+        end
+        control.caret:SetMouseEnabled(true)
+    end
+
+    if not control.label then
+        control.label = control:GetNamedChild("Label")
+        if not control.label then
+            control.label = WM:CreateControl(nil, control, CT_LABEL)
+            control.label:SetAnchor(LEFT, control, LEFT, 20, 0)
+            control.label:SetHorizontalAlignment(TEXT_ALIGN_LEFT)
+            control.label:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    if not control.progress then
+        control.progress = control:GetNamedChild("Progress")
+        if not control.progress then
+            control.progress = WM:CreateControl(nil, control, CT_LABEL)
+            control.progress:SetAnchor(RIGHT, control, RIGHT, -8, 0)
+            control.progress:SetHorizontalAlignment(TEXT_ALIGN_RIGHT)
+            control.progress:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    local quest = data.quest
+    local name = quest and (quest.displayName or quest.title or quest.name) or ""
+    local progress = questProgressText(quest)
+    control.label:SetText(name)
+    applyFontAndColor(control.label, "quest")
+    control.progress:SetText(progress)
+    applyFontAndColor(control.progress, "task")
+
+    local collapsed = data.collapsed == true
+    control.caret:SetTexture(collapsed and CARET_TEXTURE_CLOSED or CARET_TEXTURE_OPEN)
+
+    control.caret:SetHandler("OnMouseUp", function(_, button, upInside)
+        if button == LEFT_BUTTON and upInside then
+            self:ToggleCollapsed(data.questKey)
+        end
+    end)
+
+    control:SetHandler("OnMouseEnter", function()
+        Module.ShowTooltip("quest", function(tt)
+            if quest then
+                tt:AddLine(quest.title or "", "ZoFontGameBold")
+                if quest.zoneName and quest.zoneName ~= "" then
+                    tt:AddLine(quest.zoneName, "ZoFontGame")
+                end
+                if quest.stepText and quest.stepText ~= "" then
+                    tt:AddLine(quest.stepText, "ZoFontGame")
+                end
+            end
+        end)
+    end)
+
+    control:SetHandler("OnMouseExit", function()
+        Module.HideTooltip()
+    end)
+
+    control:SetHandler("OnMouseUp", function(_, button, upInside)
+        if button == LEFT_BUTTON and upInside then
+            self:ToggleCollapsed(data.questKey)
+        end
+    end)
+end
+
+function QuestSection:SetupQuestStepRow(control, data)
+    control.data = data
+    control:SetMouseEnabled(true)
+
+    if not control.label then
+        control.label = control:GetNamedChild("Label")
+        if not control.label then
+            control.label = WM:CreateControl(nil, control, CT_LABEL)
+            control.label:SetAnchor(LEFT, control, LEFT, 32, 0)
+            control.label:SetHorizontalAlignment(TEXT_ALIGN_LEFT)
+            control.label:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    if not control.progress then
+        control.progress = control:GetNamedChild("Progress")
+        if not control.progress then
+            control.progress = WM:CreateControl(nil, control, CT_LABEL)
+            control.progress:SetAnchor(RIGHT, control, RIGHT, -8, 0)
+            control.progress:SetHorizontalAlignment(TEXT_ALIGN_RIGHT)
+            control.progress:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    local text = ""
+    local progress = ""
+    if data.objective then
+        local objective = data.objective
+        text = objective.text or ""
+        if text ~= "" then
+            text = string.format("• %s", text)
+        end
+        if objective.max and objective.max > 0 then
+            progress = string.format("%d/%d", objective.current or 0, objective.max)
+        end
+    elseif data.text and data.text ~= "" then
+        text = string.format("• %s", data.text)
+    end
+
+    control.label:SetText(text)
+    applyFontAndColor(control.label, "task")
+    control.progress:SetText(progress)
+    applyFontAndColor(control.progress, "task")
+
+    control:SetHandler("OnMouseEnter", function()
+        local quest = data.quest
+        local objective = data.objective
+        Module.ShowTooltip("quest", function(tt)
+            if quest then
+                tt:AddLine(quest.title or "", "ZoFontGameBold")
+            end
+            if objective then
+                local line = objective.text or ""
+                if objective.max and objective.max > 0 then
+                    line = string.format("%s (%d/%d)", line, objective.current or 0, objective.max)
+                end
+                if line ~= "" then
+                    tt:AddLine(line, "ZoFontGame")
+                end
+            elseif data.text and data.text ~= "" then
+                tt:AddLine(data.text, "ZoFontGame")
+            end
+        end)
+    end)
+
+    control:SetHandler("OnMouseExit", function()
+        Module.HideTooltip()
+    end)
+end
+
+function QuestSection:Dispose()
+    local unsubscribe = M.Unsubscribe or (M.Core and M.Core.Unsubscribe)
+    if unsubscribe then
+        for _, entry in ipairs(self.subscriptions or {}) do
+            unsubscribe(entry.topic, entry.fn)
+        end
+    end
+    self.subscriptions = {}
+    self.listControl = nil
+end
+
+---------------------------------------------------------------------
+-- Achievement Section
+---------------------------------------------------------------------
+
+AchSection.dataTypes = {
+    ROW = 9201,
+}
+
+function AchSection:Init(listControl)
+    self.listControl = listControl
+    self.dirty = true
+    self.subscriptions = {}
+
+    local subscribe = M.Subscribe or (M.Core and M.Core.Subscribe)
+    if subscribe then
+        local achChanged = subscribe("ach:changed", function()
+            self:HandleEvent("ach:changed")
+        end)
+        table.insert(self.subscriptions, { topic = "ach:changed", fn = achChanged })
+
+        local settingsChanged = subscribe("settings:changed", function(key)
+            self:OnSettingsChanged(key)
+        end)
+        table.insert(self.subscriptions, { topic = "settings:changed", fn = settingsChanged })
+    end
+end
+
+function AchSection:RegisterRowTypes(listControl)
+    ZO_ScrollList_AddDataType(
+        listControl,
+        self.dataTypes.ROW,
+        "Nvk3UT_RowAchievementTemplate",
+        32,
+        function(control, data)
+            self:SetupAchievementRow(control, data)
+        end,
+        nil,
+        nil,
+        nil,
+        function(control)
+            control.data = nil
+            Module.HideTooltip()
+        end
+    )
+end
+
+function AchSection:OnSettingsChanged(key)
+    if type(key) ~= "string" then
+        return
+    end
+    if not key:match("^ach%.") then
+        return
+    end
+    self.dirty = true
+    Module.MarkDirty()
+end
+
+function AchSection:HandleEvent(topic)
+    if topic ~= "ach:changed" then
+        return
+    end
+    self.dirty = true
+    Module.MarkDirty()
+end
+
+function AchSection:IsVisible()
+    local settings = getAchievementSettings()
+    if settings.enabled == false then
+        return false
+    end
+
+    if shouldHideInCombat() then
+        return false
+    end
+
+    return true
+end
+
+function AchSection:IsDirty()
+    return self.dirty == true
+end
+
+function AchSection:ClearDirty()
+    self.dirty = false
+end
+
+function AchSection:BuildFeed()
+    local feed = {}
+    if not self:IsVisible() then
+        return feed
+    end
+
+    local list = M.AchievementModel and M.AchievementModel.GetList and select(1, M.AchievementModel.GetList())
+    if type(list) ~= "table" or #list == 0 then
+        return feed
+    end
+
+    for _, achievement in ipairs(list) do
+        feed[#feed + 1] = {
+            dataType = self.dataTypes.ROW,
+            achievement = achievement,
+        }
+    end
+
+    return feed
+end
+
+local function achievementProgress(achievement)
+    if not achievement or not achievement.progress then
+        return ""
+    end
+    local cur = tonumber(achievement.progress.cur) or 0
+    local max = tonumber(achievement.progress.max) or 0
+    if max <= 0 then
+        return ""
+    end
+    cur = math.max(0, math.min(max, cur))
+    return string.format("%d/%d", cur, max)
+end
+
+function AchSection:SetupAchievementRow(control, data)
+    control.data = data
+    control:SetMouseEnabled(true)
+
+    if not control.label then
+        control.label = control:GetNamedChild("Label")
+        if not control.label then
+            control.label = WM:CreateControl(nil, control, CT_LABEL)
+            control.label:SetAnchor(LEFT, control, LEFT, 4, 0)
+            control.label:SetHorizontalAlignment(TEXT_ALIGN_LEFT)
+            control.label:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    if not control.progress then
+        control.progress = control:GetNamedChild("Progress")
+        if not control.progress then
+            control.progress = WM:CreateControl(nil, control, CT_LABEL)
+            control.progress:SetAnchor(RIGHT, control, RIGHT, -8, 0)
+            control.progress:SetHorizontalAlignment(TEXT_ALIGN_RIGHT)
+            control.progress:SetVerticalAlignment(TEXT_ALIGN_CENTER)
+        end
+    end
+
+    local achievement = data.achievement
+    control.label:SetText(achievement and achievement.name or "")
+    applyFontAndColor(control.label, "achieve")
+    control.progress:SetText(achievementProgress(achievement))
+    applyFontAndColor(control.progress, "achieveTask")
+
+    control:SetHandler("OnMouseEnter", function()
+        local settings = getAchievementSettings()
+        if settings.tooltips == false then
+            return
+        end
+        Module.ShowTooltip("ach", function(tt)
+            if achievement then
+                tt:AddLine(achievement.name or "", "ZoFontGameBold")
+                if achievement.progress and achievement.progress.max and achievement.progress.max > 0 then
+                    tt:AddLine(string.format("%d / %d", achievement.progress.cur or 0, achievement.progress.max), "ZoFontGame")
+                end
+                if achievement.stages then
+                    for _, stage in ipairs(achievement.stages) do
+                        if stage.name and stage.name ~= "" then
+                            tt:AddLine(stage.name, "ZoFontGame")
+                        end
+                    end
+                end
+            end
+        end)
+    end)
+
+    control:SetHandler("OnMouseExit", function()
+        Module.HideTooltip()
+    end)
+end
+
+function AchSection:Dispose()
+    local unsubscribe = M.Unsubscribe or (M.Core and M.Core.Unsubscribe)
+    if unsubscribe then
+        for _, entry in ipairs(self.subscriptions or {}) do
+            unsubscribe(entry.topic, entry.fn)
+        end
+    end
+    self.subscriptions = {}
+    self.listControl = nil
+end
+
+---------------------------------------------------------------------
+-- Unified View Composition
+---------------------------------------------------------------------
+
+function Module.BuildUnifiedFeed()
+    local feed = {}
+
+    if QuestSection:IsVisible() then
+        local questFeed = QuestSection:BuildFeed()
+        for _, entry in ipairs(questFeed) do
+            feed[#feed + 1] = entry
+        end
+    end
+
+    local achievementsFeed = {}
+    if AchSection:IsVisible() then
+        achievementsFeed = AchSection:BuildFeed()
+    end
+
+    if #feed > 0 and #achievementsFeed > 0 then
+        feed[#feed + 1] = { dataType = DIVIDER_DATA_TYPE }
+    end
+
+    for _, entry in ipairs(achievementsFeed) do
+        feed[#feed + 1] = entry
+    end
+
+    return feed
+end
+
+local function commitFeed(feed)
+    if not Module.scrollList then
+        return
+    end
+
+    local dataList = ZO_ScrollList_GetDataList(Module.scrollList)
+    ZO_ClearNumericallyIndexedTable(dataList)
+
+    for index = 1, #feed do
+        local entry = feed[index]
+        dataList[#dataList + 1] = ZO_ScrollList_CreateDataEntry(entry.dataType, entry)
+    end
+
+    ZO_ScrollList_Commit(Module.scrollList)
+    applyAutoSize()
+end
+
+function Module.RefreshNow()
+    Module.refreshPending = false
+    if EM and EM.UnregisterForUpdate then
+        EM:UnregisterForUpdate(REFRESH_HANDLE)
+    end
+
+    if not Module.initialized then
+        return
+    end
+
+    local feed = Module.BuildUnifiedFeed()
+    commitFeed(feed)
+
+    if QuestSection:IsDirty() then
+        QuestSection:ClearDirty()
+    end
+    if AchSection:IsDirty() then
+        AchSection:ClearDirty()
+    end
+
+    applyRootHiddenState()
+end
+
+function Module.MarkDirty()
+    scheduleRefresh()
+end
+
+function Module.ForceRefresh()
+    Module.RefreshNow()
+end
+
+local function onSettingsChanged(key)
+    if type(key) ~= "string" then
+        return
+    end
+    if key:match("^tracker%.") or key == "tracker" or key == "throttle" then
+        applyLockState()
+        applyScaleAndPosition()
+        applyBackground()
+        applyRootHiddenState()
+        Module.MarkDirty()
+        return
+    end
+    if key == "quest.tooltips" or key == "ach.tooltips" then
+        Module.MarkDirty()
+    end
+end
+
+local function attachFragment()
+    if not Module.rootControl or not SCENE_MANAGER then
+        return
+    end
+
+    if not Module.fragment then
+        local fragmentClass = ZO_HUDFadeSceneFragment or ZO_SimpleSceneFragment
+        if fragmentClass then
+            Module.fragment = fragmentClass:New(Module.rootControl)
+        end
+    end
+
+    if not Module.fragment then
+        return
+    end
+
+    Module.sceneFragments = Module.sceneFragments or {}
+    for _, sceneName in ipairs(TRACKER_SCENES) do
+        if not Module.sceneFragments[sceneName] then
+            local scene = SCENE_MANAGER:GetScene(sceneName)
+            if scene and scene.AddFragment then
+                scene:AddFragment(Module.fragment)
+                Module.sceneFragments[sceneName] = true
+            end
+        end
+    end
+end
+
+local function createControls()
+    if Module.rootControl then
+        return
+    end
+
+    local root = WM:CreateTopLevelWindow(ROOT_CONTROL_NAME)
+    root:SetClampedToScreen(true)
+    root:SetDrawTier(DT_HIGH)
+    root:SetMovable(true)
+    root:SetMouseEnabled(true)
+    root:SetResizeHandleSize(8)
+    root:SetDimensionConstraints(MIN_WIDTH, MIN_HEIGHT, 800, 900)
+    root:ClearAnchors()
+    root:SetAnchor(TOPLEFT, GuiRoot, TOPLEFT, 400, 200)
+
+    root:SetHandler("OnMoveStop", function()
+        savePosition()
+    end)
+
+    root:SetHandler("OnResizeStop", function()
+        saveDimensions()
+        Module.MarkDirty()
+    end)
+
+    root:SetHandler("OnHide", function()
+        Module.HideTooltip()
+    end)
+
+    local backdrop = WM:CreateControl(nil, root, CT_BACKDROP)
+    backdrop:SetAnchorFill(root)
+    backdrop:SetHidden(true)
+
+    local list = WM:CreateControlFromVirtual(LIST_CONTROL_NAME, root, "ZO_ScrollList")
+    list:ClearAnchors()
+    list:SetAnchor(TOPLEFT, root, TOPLEFT, PADDING_X, PADDING_Y)
+    list:SetAnchor(BOTTOMRIGHT, root, BOTTOMRIGHT, -PADDING_X, -PADDING_Y)
+
+    Module.rootControl = root
+    Module.backdrop = backdrop
+    Module.scrollList = list
+
+    registerDividerDataType()
+    attachFragment()
+    applyScaleAndPosition()
+    applyLockState()
+    applyBackground()
+    applyRootHiddenState()
+end
+
+function Module.ApplySettingsFromSV()
+    applyScaleAndPosition()
+    applyLockState()
+    applyBackground()
+    applyRootHiddenState()
+    applyAutoSize()
+end
+
+function Module.ApplyLockState()
+    applyLockState()
+end
+
+function Module.ApplyBackground()
+    applyBackground()
+end
+
+function Module.ApplyScaleFromSettings()
+    applyScaleAndPosition()
+end
+
+function Module.SetRootHidden(hidden)
+    if Module.rootControl then
+        Module.rootControl:SetHidden(hidden)
+    end
+end
+
+function Module.GetRootControl()
+    return Module.rootControl
+end
+
+function Module.GetScrollList()
+    return Module.scrollList
+end
+
+function Module.GetFragment()
+    return Module.fragment
+end
+
+function Module.Init()
+    if Module.initialized then
+        return
+    end
+
+    createControls()
+
+    QuestSection:Init(Module.scrollList)
+    AchSection:Init(Module.scrollList)
+    QuestSection:RegisterRowTypes(Module.scrollList)
+    AchSection:RegisterRowTypes(Module.scrollList)
+
+    local subscribe = M.Subscribe or (M.Core and M.Core.Subscribe)
+    if subscribe then
+        Module.settingsSubscription = subscribe("settings:changed", function(key)
+            onSettingsChanged(key)
+        end)
+    end
+
+    Module.initialized = true
+    Module.MarkDirty()
+
+    if M and M.Tracker and M.Tracker.NotifyViewReady then
+        M.Tracker.NotifyViewReady()
+    end
+end
+
+function Module.Dispose()
+    if Module.settingsSubscription then
+        local unsubscribe = M.Unsubscribe or (M.Core and M.Core.Unsubscribe)
+        if unsubscribe then
+            unsubscribe("settings:changed", Module.settingsSubscription)
+        end
+        Module.settingsSubscription = nil
+    end
+
+    QuestSection:Dispose()
+    AchSection:Dispose()
+
+    if Module.fragment and SCENE_MANAGER then
+        for sceneName, _ in pairs(Module.sceneFragments or {}) do
+            local scene = SCENE_MANAGER:GetScene(sceneName)
+            if scene and scene.RemoveFragment then
+                scene:RemoveFragment(Module.fragment)
+            end
+        end
+    end
+
+    Module.rootControl = nil
+    Module.scrollList = nil
+    Module.backdrop = nil
+    Module.fragment = nil
+    Module.sceneFragments = nil
+    Module.initialized = false
+end
+
+return

--- a/Nvk3UT_UI.lua
+++ b/Nvk3UT_UI.lua
@@ -110,189 +110,982 @@ function M.BuildLAM()
     registerForRefresh = true,
     registerForDefaults = true,
   }
-  LAM:RegisterAddonPanel("Nvk3UT_Panel", panel)
+  local panelControl = LAM:RegisterAddonPanel("Nvk3UT_Panel", panel)
+  if Nvk3UT and Nvk3UT.Tracker and Nvk3UT.Tracker.RegisterLamPanel then
+    Nvk3UT.Tracker.RegisterLamPanel(panelControl)
+  end
+
+  local function getTracker()
+    return Nvk3UT and Nvk3UT.Tracker
+  end
+
+  local function trackerSV()
+    local root = Nvk3UT and Nvk3UT.sv
+    if root then
+      root.tracker = root.tracker or {}
+      local sv = root.tracker
+      sv.behavior = sv.behavior or {}
+      sv.background = sv.background or {}
+      sv.fonts = sv.fonts or {}
+      sv.pos = sv.pos or {}
+      sv.collapseState = sv.collapseState or { zones = {}, quests = {}, achieves = {} }
+      return sv
+    end
+    local tracker = getTracker()
+    if tracker and tracker.sv then
+      return tracker.sv
+    end
+    return nil
+  end
+
+  local FONT_FACES = {
+    "ZoFontGame",
+    "ZoFontGameBold",
+    "ZoFontGameMedium",
+    "ZoFontGameLargeBold",
+    "ZoFontHeader",
+    "ZoFontHeader2",
+    "ZoFontHeader3",
+    "ZoFontWinH1",
+    "ZoFontWinH2",
+    "ZoFontWinH3",
+  }
+
+  local FONT_EFFECT_LABELS = {
+    "Keine",
+    "Outline",
+    "Dicke Outline",
+    "Shadow",
+    "Soft Shadow (dünn)",
+    "Soft Shadow (dick)",
+  }
+
+  local FONT_EFFECT_VALUES = {
+    "none",
+    "outline",
+    "thick-outline",
+    "shadow",
+    "soft-shadow-thin",
+    "soft-shadow-thick",
+  }
+
+  local TRACKER_FONT_DEFAULTS = {
+    category = { face = "ZoFontHeader2", effect = "soft-shadow-thin", size = 24, color = { r = 0.89, g = 0.82, b = 0.67, a = 1 } },
+    quest = { face = "ZoFontGameBold", effect = "soft-shadow-thin", size = 20, color = { r = 1, g = 0.82, b = 0.1, a = 1 } },
+    task = { face = "ZoFontGame", effect = "soft-shadow-thin", size = 18, color = { r = 0.9, g = 0.9, b = 0.9, a = 1 } },
+    achieve = { face = "ZoFontGameBold", effect = "soft-shadow-thin", size = 20, color = { r = 1, g = 0.82, b = 0.1, a = 1 } },
+    achieveTask = { face = "ZoFontGame", effect = "soft-shadow-thin", size = 18, color = { r = 0.9, g = 0.9, b = 0.9, a = 1 } },
+  }
+
+  local TRACKER_THROTTLE_DEFAULT = 150
+
+  local BEHAVIOR_DEFAULTS = {
+    hideDefault = false,
+    hideInCombat = false,
+    locked = false,
+    autoGrowV = true,
+    autoGrowH = false,
+    autoExpandNewQuests = false,
+    alwaysExpandAchievements = false,
+    tooltips = true,
+  }
+
+  local BACKGROUND_DEFAULTS = {
+    enabled = false,
+    border = false,
+    alpha = 60,
+    hideWhenLocked = false,
+  }
+
+  local function roundToInt(value)
+    return math.floor((value or 0) + 0.5)
+  end
+
+  local function getFontConfig(section)
+    local sv = trackerSV()
+    if not sv then
+      return TRACKER_FONT_DEFAULTS[section]
+    end
+    sv.fonts = sv.fonts or {}
+    sv.fonts[section] = sv.fonts[section] or {}
+    return sv.fonts[section]
+  end
+
+  local function applyFontChange(section, field, value)
+    local cfg = getFontConfig(section)
+    cfg[field] = value
+    local tracker = getTracker()
+    if tracker and tracker.SetFontOption then
+      tracker.SetFontOption(section, field, value)
+    end
+  end
+
+  local function getFontFace(section)
+    local cfg = getFontConfig(section)
+    return cfg.face or TRACKER_FONT_DEFAULTS[section].face
+  end
+
+  local function setFontFace(section, face)
+    applyFontChange(section, "face", face)
+  end
+
+  local function getFontEffect(section)
+    local cfg = getFontConfig(section)
+    return cfg.effect or TRACKER_FONT_DEFAULTS[section].effect
+  end
+
+  local function setFontEffect(section, effect)
+    applyFontChange(section, "effect", effect)
+  end
+
+  local function getFontSize(section)
+    local cfg = getFontConfig(section)
+    return cfg.size or TRACKER_FONT_DEFAULTS[section].size
+  end
+
+  local function setFontSize(section, size)
+    applyFontChange(section, "size", roundToInt(size))
+  end
+
+  local function getFontColor(section)
+    local cfg = getFontConfig(section)
+    local color = cfg.color or TRACKER_FONT_DEFAULTS[section].color
+    return color.r or 1, color.g or 1, color.b or 1, color.a or 1
+  end
+
+  local function setFontColor(section, r, g, b, a)
+    local cfg = getFontConfig(section)
+    cfg.color = { r = r, g = g, b = b, a = a }
+    local tracker = getTracker()
+    if tracker and tracker.SetFontColor then
+      tracker.SetFontColor(section, r, g, b, a)
+    end
+  end
+
+  local function trackerEnabled()
+    local sv = trackerSV()
+    if not sv then
+      return true
+    end
+    return sv.enabled ~= false
+  end
+
+  local function setTrackerEnabled(value)
+    local sv = trackerSV()
+    if sv then
+      sv.enabled = value and true or false
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetEnabled then
+      tracker.SetEnabled(value)
+    end
+  end
+
+  local function trackerShowsQuests()
+    local sv = trackerSV()
+    if not sv then
+      return true
+    end
+    return sv.showQuests ~= false
+  end
+
+  local function setTrackerShowsQuests(value)
+    local sv = trackerSV()
+    if sv then
+      sv.showQuests = value and true or false
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetShowQuests then
+      tracker.SetShowQuests(value)
+    end
+  end
+
+  local function trackerShowsAchievements()
+    local sv = trackerSV()
+    if not sv then
+      return true
+    end
+    return sv.showAchievements ~= false
+  end
+
+  local function setTrackerShowsAchievements(value)
+    local sv = trackerSV()
+    if sv then
+      sv.showAchievements = value and true or false
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetShowAchievements then
+      tracker.SetShowAchievements(value)
+    end
+  end
+
+  local function getBehavior(key)
+    local sv = trackerSV()
+    if not sv then
+      if key == "tooltips" then
+        return BEHAVIOR_DEFAULTS.tooltips
+      end
+      return BEHAVIOR_DEFAULTS[key] == true
+    end
+    local behavior = sv.behavior or {}
+    if key == "tooltips" then
+      if behavior.tooltips == nil then
+        return true
+      end
+      return behavior.tooltips
+    end
+    return behavior[key] == true
+  end
+
+  local function setBehavior(key, value)
+    local sv = trackerSV()
+    if sv then
+      sv.behavior = sv.behavior or {}
+      if key == "tooltips" then
+        sv.behavior.tooltips = value and true or false
+      else
+        sv.behavior[key] = value and true or false
+      end
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetBehaviorOption then
+      tracker.SetBehaviorOption(key, value)
+    end
+  end
+
+  local function getBackgroundValue(key)
+    local sv = trackerSV()
+    if not sv then
+      return BACKGROUND_DEFAULTS[key]
+    end
+    local bg = sv.background or {}
+    if key == "alpha" then
+      return tonumber(bg.alpha) or BACKGROUND_DEFAULTS.alpha
+    end
+    local flag = bg[key]
+    if flag == nil then
+      return BACKGROUND_DEFAULTS[key]
+    end
+    return flag
+  end
+
+  local function setBackgroundValue(key, value)
+    local sv = trackerSV()
+    if not sv then
+      return
+    end
+    sv.background = sv.background or {}
+    if key == "alpha" then
+      sv.background.alpha = value
+    else
+      sv.background[key] = value and true or false
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetBackgroundOption then
+      tracker.SetBackgroundOption(key, value)
+    end
+  end
+
+  local function getThrottle()
+    local sv = trackerSV()
+    if not sv then
+      return TRACKER_THROTTLE_DEFAULT
+    end
+    local delay = tonumber(sv.throttleMs)
+    if not delay then
+      return TRACKER_THROTTLE_DEFAULT
+    end
+    return delay
+  end
+
+  local function setThrottle(value)
+    local numeric = roundToInt(value)
+    if numeric < 0 then
+      numeric = 0
+    end
+    local sv = trackerSV()
+    if sv then
+      sv.throttleMs = numeric
+    end
+    local tracker = getTracker()
+    if tracker and tracker.SetThrottle then
+      tracker.SetThrottle(numeric)
+    end
+  end
 
   local opts = {
-    { type = "header", name = "Anzeige" },
     {
-      type = "checkbox",
-      name = "Status über dem Kompass anzeigen",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.showStatus
-      end,
-      setFunc = function(v)
-        if Nvk3UT.sv and Nvk3UT.sv.ui then
-          Nvk3UT.sv.ui.showStatus = v
-        end
-        Nvk3UT.UI.UpdateStatus()
-      end,
-      default = true,
-    },
-    { type = "header", name = "Optionen" },
-    {
-      type = "dropdown",
-      name = "Favoritenspeicherung:",
-      choices = { "Account-Weit", "Charakter-Weit" },
-      getFunc = function()
-        local s = (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.favScope) or "account"
-        return (s == "character" and "Charakter-Weit") or "Account-Weit"
-      end,
-      setFunc = function(label)
-        local old = (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.favScope) or "account"
-        local new = (label == "Charakter-Weit") and "character" or "account"
-        if Nvk3UT.sv and Nvk3UT.sv.ui then
-          Nvk3UT.sv.ui.favScope = new
-        end
-        if Nvk3UT.FavoritesData and Nvk3UT.FavoritesData.MigrateScope then
-          Nvk3UT.FavoritesData.MigrateScope(old, new)
-        end
-        if Nvk3UT.UI and Nvk3UT.UI.UpdateStatus then
-          Nvk3UT.UI.UpdateStatus()
-        end
-      end,
-      tooltip = "Speichert und zählt Favoriten account-weit oder charakter-weit.",
-    },
-    {
-      type = "dropdown",
-      name = "Kürzlich-Zeitraum:",
-      choices = { "Alle", "7 Tage", "30 Tage" },
-      getFunc = function()
-        local w = (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.recentWindow) or 0
-        return (w == 7 and "7 Tage") or (w == 30 and "30 Tage") or "Alle"
-      end,
-      setFunc = function(label)
-        local w = (label == "7 Tage" and 7) or (label == "30 Tage" and 30) or 0
-        if Nvk3UT.sv and Nvk3UT.sv.ui then
-          Nvk3UT.sv.ui.recentWindow = w
-        end
-        if Nvk3UT.UI and Nvk3UT.UI.UpdateStatus then
-          Nvk3UT.UI.UpdateStatus()
-        end
-      end,
-      tooltip = "Wähle, welche Zeitspanne für Kürzlich gezählt/angezeigt wird.",
-    },
-    {
-      type = "dropdown",
-      name = "Kürzlich - Maximum:",
-      choices = { "50", "100", "250" },
-      getFunc = function()
-        return tostring((Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.recentMax) or 100)
-      end,
-      setFunc = function(label)
-        local v = tonumber(label) or 100
-        if Nvk3UT.sv and Nvk3UT.sv.ui then
-          Nvk3UT.sv.ui.recentMax = v
-        end
-        if Nvk3UT.UI and Nvk3UT.UI.UpdateStatus then
-          Nvk3UT.UI.UpdateStatus()
-        end
-      end,
-      tooltip = "Hardcap für die Anzahl der Kürzlich-Einträge.",
-    },
-
-    { type = "header", name = "Funktionen" },
-    {
-      type = "checkbox",
-      name = "Errungenschafts-Tooltips ein",
-      getFunc = function()
-        return (Nvk3UT.sv and Nvk3UT.sv.features and (Nvk3UT.sv.features.tooltips ~= false))
-      end,
-      setFunc = function(v)
-        if Nvk3UT.sv then
-          Nvk3UT.sv.features = Nvk3UT.sv.features or {}
-          Nvk3UT.sv.features.tooltips = v
-        end
-        if Nvk3UT.Tooltips and Nvk3UT.Tooltips.Enable then
-          Nvk3UT.Tooltips.Enable(v)
-        end
-      end,
-      default = true,
-    },
-
-    {
-      type = "checkbox",
-      name = "Abgeschlossen aktiv",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.completed
-      end,
-      setFunc = function(v)
-        Nvk3UT.sv.features = Nvk3UT.sv.features or {}
-        Nvk3UT.sv.features.completed = v
-        M.ApplyFeatureToggles()
-      end,
-      default = true,
-    },
-    {
-      type = "checkbox",
-      name = "Favoriten aktiv",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.favorites
-      end,
-      setFunc = function(v)
-        Nvk3UT.sv.features = Nvk3UT.sv.features or {}
-        Nvk3UT.sv.features.favorites = v
-        M.ApplyFeatureToggles()
-      end,
-      default = true,
-    },
-    {
-      type = "checkbox",
-      name = "Kürzlich aktiv",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.recent
-      end,
-      setFunc = function(v)
-        Nvk3UT.sv.features = Nvk3UT.sv.features or {}
-        Nvk3UT.sv.features.recent = v
-        M.ApplyFeatureToggles()
-      end,
-      default = true,
-    },
-    {
-      type = "checkbox",
-      name = "To-Do-Liste aktiv",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.todo
-      end,
-      setFunc = function(v)
-        Nvk3UT.sv.features = Nvk3UT.sv.features or {}
-        Nvk3UT.sv.features.todo = v
-        M.ApplyFeatureToggles()
-      end,
-      default = true,
-    },
-    { type = "header", name = "Debug" },
-    {
-      type = "checkbox",
-      name = "Debug aktivieren",
-      getFunc = function()
-        return Nvk3UT.sv and Nvk3UT.sv.debug
-      end,
-      setFunc = function(v)
-        if Nvk3UT.sv then
-          Nvk3UT.sv.debug = v
-        end
-      end,
-      default = false,
-    },
-    {
-      type = "button",
-      name = "Self-Test ausführen",
-      func = function()
-        if Nvk3UT and Nvk3UT.SelfTest and Nvk3UT.SelfTest.Run then
-          Nvk3UT.SelfTest.Run()
-        end
-      end,
-      tooltip = "Führt einen kompakten Integritäts-Check aus. Bei aktiviertem Debug erscheinen ausführliche Chat-Logs.",
+      type = "submenu",
+      name = "Funktionen",
+      reference = "Nvk3UT_LAM_Functions",
+      controls = {
+        {
+          type = "checkbox",
+          name = "Status über dem Kompass anzeigen",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.showStatus
+          end,
+          setFunc = function(value)
+            if Nvk3UT.sv and Nvk3UT.sv.ui then
+              Nvk3UT.sv.ui.showStatus = value
+            end
+            M.UpdateStatus()
+          end,
+          default = true,
+        },
+        {
+          type = "dropdown",
+          name = "Favoritenspeicherung:",
+          choices = { "Account-Weit", "Charakter-Weit" },
+          choicesValues = { "account", "character" },
+          getFunc = function()
+            return (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.favScope) or "account"
+          end,
+          setFunc = function(value)
+            local old = (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.favScope) or "account"
+            if Nvk3UT.sv and Nvk3UT.sv.ui then
+              Nvk3UT.sv.ui.favScope = value
+            end
+            if Nvk3UT.FavoritesData and Nvk3UT.FavoritesData.MigrateScope then
+              Nvk3UT.FavoritesData.MigrateScope(old, value)
+            end
+            M.UpdateStatus()
+          end,
+          tooltip = "Speichert und zählt Favoriten account-weit oder charakter-weit.",
+        },
+        {
+          type = "dropdown",
+          name = "Kürzlich-Zeitraum:",
+          choices = { "Alle", "7 Tage", "30 Tage" },
+          choicesValues = { 0, 7, 30 },
+          getFunc = function()
+            return (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.recentWindow) or 0
+          end,
+          setFunc = function(value)
+            if Nvk3UT.sv and Nvk3UT.sv.ui then
+              Nvk3UT.sv.ui.recentWindow = value
+            end
+            M.UpdateStatus()
+          end,
+          tooltip = "Wähle, welche Zeitspanne für Kürzlich gezählt/angezeigt wird.",
+        },
+        {
+          type = "dropdown",
+          name = "Kürzlich - Maximum:",
+          choices = { "50", "100", "250" },
+          choicesValues = { 50, 100, 250 },
+          getFunc = function()
+            return (Nvk3UT.sv and Nvk3UT.sv.ui and Nvk3UT.sv.ui.recentMax) or 100
+          end,
+          setFunc = function(value)
+            if Nvk3UT.sv and Nvk3UT.sv.ui then
+              Nvk3UT.sv.ui.recentMax = value
+            end
+            M.UpdateStatus()
+          end,
+          tooltip = "Hardcap für die Anzahl der Kürzlich-Einträge.",
+        },
+        {
+          type = "checkbox",
+          name = "Errungenschafts-Tooltips ein",
+          getFunc = function()
+            return (Nvk3UT.sv and Nvk3UT.sv.features and (Nvk3UT.sv.features.tooltips ~= false))
+          end,
+          setFunc = function(value)
+            if Nvk3UT.sv then
+              Nvk3UT.sv.features = Nvk3UT.sv.features or {}
+              Nvk3UT.sv.features.tooltips = value
+            end
+            if Nvk3UT.Tooltips and Nvk3UT.Tooltips.Enable then
+              Nvk3UT.Tooltips.Enable(value)
+            end
+          end,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Abgeschlossen aktiv",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.completed
+          end,
+          setFunc = function(value)
+            Nvk3UT.sv.features = Nvk3UT.sv.features or {}
+            Nvk3UT.sv.features.completed = value
+            M.ApplyFeatureToggles()
+          end,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Favoriten aktiv",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.favorites
+          end,
+          setFunc = function(value)
+            Nvk3UT.sv.features = Nvk3UT.sv.features or {}
+            Nvk3UT.sv.features.favorites = value
+            M.ApplyFeatureToggles()
+          end,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Kürzlich aktiv",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.recent
+          end,
+          setFunc = function(value)
+            Nvk3UT.sv.features = Nvk3UT.sv.features or {}
+            Nvk3UT.sv.features.recent = value
+            M.ApplyFeatureToggles()
+          end,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "To-Do-Liste aktiv",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.features and Nvk3UT.sv.features.todo
+          end,
+          setFunc = function(value)
+            Nvk3UT.sv.features = Nvk3UT.sv.features or {}
+            Nvk3UT.sv.features.todo = value
+            M.ApplyFeatureToggles()
+          end,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Questtracker aktiv",
+          getFunc = trackerEnabled,
+          setFunc = setTrackerEnabled,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Quests im Questtracker tracken",
+          getFunc = trackerShowsQuests,
+          setFunc = setTrackerShowsQuests,
+          default = true,
+        },
+        {
+          type = "checkbox",
+          name = "Errungenschaften im Questtracker tracken",
+          getFunc = trackerShowsAchievements,
+          setFunc = setTrackerShowsAchievements,
+          default = true,
+        },
+      },
     },
     {
-      type = "button",
-      name = "UI neu laden",
-      func = function()
-        ReloadUI()
-      end,
+      type = "submenu",
+      name = "QuestTracker Verhalten",
+      reference = "Nvk3UT_LAM_Behavior",
+      controls = {
+        {
+          type = "checkbox",
+          name = "Default Questtracker verbergen",
+          getFunc = function()
+            return getBehavior("hideDefault")
+          end,
+          setFunc = function(value)
+            setBehavior("hideDefault", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.hideDefault,
+        },
+        {
+          type = "checkbox",
+          name = "Quest Tracker im Kampf ausblenden",
+          getFunc = function()
+            return getBehavior("hideInCombat")
+          end,
+          setFunc = function(value)
+            setBehavior("hideInCombat", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.hideInCombat,
+        },
+        {
+          type = "checkbox",
+          name = "Quest Tracker sperren",
+          getFunc = function()
+            return getBehavior("locked")
+          end,
+          setFunc = function(value)
+            setBehavior("locked", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.locked,
+        },
+        {
+          type = "checkbox",
+          name = "Quest Tracker automatisch vertikal vergrößern",
+          getFunc = function()
+            return getBehavior("autoGrowV")
+          end,
+          setFunc = function(value)
+            setBehavior("autoGrowV", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.autoGrowV,
+        },
+        {
+          type = "checkbox",
+          name = "Questtracker automatisch horizontal vergrößern",
+          getFunc = function()
+            return getBehavior("autoGrowH")
+          end,
+          setFunc = function(value)
+            setBehavior("autoGrowH", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.autoGrowH,
+        },
+        {
+          type = "checkbox",
+          name = "Neue Quests automatisch aufklappen",
+          getFunc = function()
+            return getBehavior("autoExpandNewQuests")
+          end,
+          setFunc = function(value)
+            setBehavior("autoExpandNewQuests", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.autoExpandNewQuests,
+        },
+        {
+          type = "checkbox",
+          name = "Errungenschaften immer aufklappen",
+          getFunc = function()
+            return getBehavior("alwaysExpandAchievements")
+          end,
+          setFunc = function(value)
+            setBehavior("alwaysExpandAchievements", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.alwaysExpandAchievements,
+        },
+        {
+          type = "checkbox",
+          name = "Tooltips im Questtracker anzeigen",
+          getFunc = function()
+            return getBehavior("tooltips")
+          end,
+          setFunc = function(value)
+            setBehavior("tooltips", value)
+          end,
+          default = BEHAVIOR_DEFAULTS.tooltips,
+        },
+        {
+          type = "slider",
+          name = "Aktualisierungsverzögerung (ms)",
+          min = 0,
+          max = 1000,
+          step = 10,
+          getFunc = getThrottle,
+          setFunc = setThrottle,
+          default = TRACKER_THROTTLE_DEFAULT,
+          tooltip = "Zeit zwischen automatischen Aktualisierungen. 0 deaktiviert die Verzögerung.",
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Questtracker Background",
+      reference = "Nvk3UT_LAM_Background",
+      controls = {
+        {
+          type = "checkbox",
+          name = "Background aktivieren",
+          getFunc = function()
+            return getBackgroundValue("enabled")
+          end,
+          setFunc = function(value)
+            setBackgroundValue("enabled", value)
+          end,
+          default = BACKGROUND_DEFAULTS.enabled,
+        },
+        {
+          type = "checkbox",
+          name = "Rand aktivieren",
+          getFunc = function()
+            return getBackgroundValue("border")
+          end,
+          setFunc = function(value)
+            setBackgroundValue("border", value)
+          end,
+          default = BACKGROUND_DEFAULTS.border,
+        },
+        {
+          type = "slider",
+          name = "Background Transparenz",
+          min = 0,
+          max = 100,
+          step = 5,
+          getFunc = function()
+            return getBackgroundValue("alpha")
+          end,
+          setFunc = function(value)
+            setBackgroundValue("alpha", roundToInt(value))
+          end,
+          default = BACKGROUND_DEFAULTS.alpha,
+        },
+        {
+          type = "checkbox",
+          name = "Background bei Sperren ausblenden",
+          getFunc = function()
+            return getBackgroundValue("hideWhenLocked")
+          end,
+          setFunc = function(value)
+            setBackgroundValue("hideWhenLocked", value)
+          end,
+          default = BACKGROUND_DEFAULTS.hideWhenLocked,
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Kategorie Optionen",
+      reference = "Nvk3UT_LAM_Font_Category",
+      controls = {
+        {
+          type = "dropdown",
+          name = "Kategorie Font",
+          choices = FONT_FACES,
+          getFunc = function()
+            return getFontFace("category")
+          end,
+          setFunc = function(value)
+            setFontFace("category", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.category.face,
+        },
+        {
+          type = "dropdown",
+          name = "Kategorie Font Effekte",
+          choices = FONT_EFFECT_LABELS,
+          choicesValues = FONT_EFFECT_VALUES,
+          getFunc = function()
+            return getFontEffect("category")
+          end,
+          setFunc = function(value)
+            setFontEffect("category", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.category.effect,
+        },
+        {
+          type = "slider",
+          name = "Kategorie Schriftgröße",
+          min = 16,
+          max = 40,
+          step = 1,
+          getFunc = function()
+            return getFontSize("category")
+          end,
+          setFunc = function(value)
+            setFontSize("category", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.category.size,
+        },
+        {
+          type = "colorpicker",
+          name = "Kategorie Font Farbe",
+          getFunc = function()
+            return getFontColor("category")
+          end,
+          setFunc = function(r, g, b, a)
+            setFontColor("category", r, g, b, a)
+          end,
+          default = {
+            TRACKER_FONT_DEFAULTS.category.color.r,
+            TRACKER_FONT_DEFAULTS.category.color.g,
+            TRACKER_FONT_DEFAULTS.category.color.b,
+            TRACKER_FONT_DEFAULTS.category.color.a,
+          },
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Quest Optionen",
+      reference = "Nvk3UT_LAM_Font_Quest",
+      controls = {
+        {
+          type = "dropdown",
+          name = "Quest Font",
+          choices = FONT_FACES,
+          getFunc = function()
+            return getFontFace("quest")
+          end,
+          setFunc = function(value)
+            setFontFace("quest", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.quest.face,
+        },
+        {
+          type = "dropdown",
+          name = "Quest Font Effekte",
+          choices = FONT_EFFECT_LABELS,
+          choicesValues = FONT_EFFECT_VALUES,
+          getFunc = function()
+            return getFontEffect("quest")
+          end,
+          setFunc = function(value)
+            setFontEffect("quest", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.quest.effect,
+        },
+        {
+          type = "slider",
+          name = "Quest Size",
+          min = 14,
+          max = 32,
+          step = 1,
+          getFunc = function()
+            return getFontSize("quest")
+          end,
+          setFunc = function(value)
+            setFontSize("quest", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.quest.size,
+        },
+        {
+          type = "colorpicker",
+          name = "Quest Color",
+          getFunc = function()
+            return getFontColor("quest")
+          end,
+          setFunc = function(r, g, b, a)
+            setFontColor("quest", r, g, b, a)
+          end,
+          default = {
+            TRACKER_FONT_DEFAULTS.quest.color.r,
+            TRACKER_FONT_DEFAULTS.quest.color.g,
+            TRACKER_FONT_DEFAULTS.quest.color.b,
+            TRACKER_FONT_DEFAULTS.quest.color.a,
+          },
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Quest Aufgaben",
+      reference = "Nvk3UT_LAM_Font_QuestTasks",
+      controls = {
+        {
+          type = "dropdown",
+          name = "Aufgaben Font",
+          choices = FONT_FACES,
+          getFunc = function()
+            return getFontFace("task")
+          end,
+          setFunc = function(value)
+            setFontFace("task", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.task.face,
+        },
+        {
+          type = "dropdown",
+          name = "Aufgaben Font Effekte",
+          choices = FONT_EFFECT_LABELS,
+          choicesValues = FONT_EFFECT_VALUES,
+          getFunc = function()
+            return getFontEffect("task")
+          end,
+          setFunc = function(value)
+            setFontEffect("task", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.task.effect,
+        },
+        {
+          type = "slider",
+          name = "Aufgaben Größe",
+          min = 12,
+          max = 28,
+          step = 1,
+          getFunc = function()
+            return getFontSize("task")
+          end,
+          setFunc = function(value)
+            setFontSize("task", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.task.size,
+        },
+        {
+          type = "colorpicker",
+          name = "Aufgaben Farbe",
+          getFunc = function()
+            return getFontColor("task")
+          end,
+          setFunc = function(r, g, b, a)
+            setFontColor("task", r, g, b, a)
+          end,
+          default = {
+            TRACKER_FONT_DEFAULTS.task.color.r,
+            TRACKER_FONT_DEFAULTS.task.color.g,
+            TRACKER_FONT_DEFAULTS.task.color.b,
+            TRACKER_FONT_DEFAULTS.task.color.a,
+          },
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Errungenschaften Optionen",
+      reference = "Nvk3UT_LAM_Font_Achievements",
+      controls = {
+        {
+          type = "dropdown",
+          name = "Errungenschaft Font",
+          choices = FONT_FACES,
+          getFunc = function()
+            return getFontFace("achieve")
+          end,
+          setFunc = function(value)
+            setFontFace("achieve", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieve.face,
+        },
+        {
+          type = "dropdown",
+          name = "Errungenschaft Font Effekte",
+          choices = FONT_EFFECT_LABELS,
+          choicesValues = FONT_EFFECT_VALUES,
+          getFunc = function()
+            return getFontEffect("achieve")
+          end,
+          setFunc = function(value)
+            setFontEffect("achieve", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieve.effect,
+        },
+        {
+          type = "slider",
+          name = "Errungenschaft Size",
+          min = 14,
+          max = 32,
+          step = 1,
+          getFunc = function()
+            return getFontSize("achieve")
+          end,
+          setFunc = function(value)
+            setFontSize("achieve", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieve.size,
+        },
+        {
+          type = "colorpicker",
+          name = "Errungenschaft Color",
+          getFunc = function()
+            return getFontColor("achieve")
+          end,
+          setFunc = function(r, g, b, a)
+            setFontColor("achieve", r, g, b, a)
+          end,
+          default = {
+            TRACKER_FONT_DEFAULTS.achieve.color.r,
+            TRACKER_FONT_DEFAULTS.achieve.color.g,
+            TRACKER_FONT_DEFAULTS.achieve.color.b,
+            TRACKER_FONT_DEFAULTS.achieve.color.a,
+          },
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Errungenschaften Aufgaben",
+      reference = "Nvk3UT_LAM_Font_AchievementTasks",
+      controls = {
+        {
+          type = "dropdown",
+          name = "Aufgaben Font (Errungenschaften)",
+          choices = FONT_FACES,
+          getFunc = function()
+            return getFontFace("achieveTask")
+          end,
+          setFunc = function(value)
+            setFontFace("achieveTask", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieveTask.face,
+        },
+        {
+          type = "dropdown",
+          name = "Aufgaben Font Effekte (Errungenschaften)",
+          choices = FONT_EFFECT_LABELS,
+          choicesValues = FONT_EFFECT_VALUES,
+          getFunc = function()
+            return getFontEffect("achieveTask")
+          end,
+          setFunc = function(value)
+            setFontEffect("achieveTask", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieveTask.effect,
+        },
+        {
+          type = "slider",
+          name = "Aufgaben Größe (Errungenschaften)",
+          min = 12,
+          max = 28,
+          step = 1,
+          getFunc = function()
+            return getFontSize("achieveTask")
+          end,
+          setFunc = function(value)
+            setFontSize("achieveTask", value)
+          end,
+          default = TRACKER_FONT_DEFAULTS.achieveTask.size,
+        },
+        {
+          type = "colorpicker",
+          name = "Aufgaben Farbe (Errungenschaften)",
+          getFunc = function()
+            return getFontColor("achieveTask")
+          end,
+          setFunc = function(r, g, b, a)
+            setFontColor("achieveTask", r, g, b, a)
+          end,
+          default = {
+            TRACKER_FONT_DEFAULTS.achieveTask.color.r,
+            TRACKER_FONT_DEFAULTS.achieveTask.color.g,
+            TRACKER_FONT_DEFAULTS.achieveTask.color.b,
+            TRACKER_FONT_DEFAULTS.achieveTask.color.a,
+          },
+        },
+      },
+    },
+    {
+      type = "submenu",
+      name = "Debug",
+      reference = "Nvk3UT_LAM_Debug",
+      controls = {
+        {
+          type = "checkbox",
+          name = "Debug aktivieren",
+          getFunc = function()
+            return Nvk3UT.sv and Nvk3UT.sv.debug
+          end,
+          setFunc = function(value)
+            if Nvk3UT.sv then
+              Nvk3UT.sv.debug = value
+            end
+          end,
+          default = false,
+        },
+        {
+          type = "button",
+          name = "Self-Test ausführen",
+          func = function()
+            if Nvk3UT and Nvk3UT.SelfTest and Nvk3UT.SelfTest.Run then
+              Nvk3UT.SelfTest.Run()
+            end
+          end,
+          tooltip = "Führt einen kompakten Integritäts-Check aus. Bei aktiviertem Debug erscheinen ausführliche Chat-Logs.",
+        },
+        {
+          type = "button",
+          name = "UI neu laden",
+          func = function()
+            ReloadUI()
+          end,
+        },
+      },
     },
   }
+
   LAM:RegisterOptionControls("Nvk3UT_Panel", opts)
 end
 


### PR DESCRIPTION
## Summary
- add a publish queue guard and SANITY REPORT note so the tracker core can safely coalesce re-entrant notifications without losing callbacks
- introduce the `/nvk sanity` diagnostics slash command to validate module APIs, feeds, and settings dispatch while keeping existing section tests intact

## Testing
- Not run (ESO API unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68f8fbd56fd8832aa7cea38f35f7a7e9