### PR TITLE
Add Lua quality automation and CI gate

### DIFF
--- a/.github/workflows/lua-quality.yml
+++ b/.github/workflows/lua-quality.yml
@@ -1,0 +1,26 @@
+name: Lua Quality Checks
+
+on:
+  pull_request:
+    paths:
+      - '**/*.lua'
+      - '.luacheckrc'
+      - 'stylua.toml'
+      - 'Makefile'
+      - 'scripts/**'
+      - '.github/workflows/lua-quality.yml'
+
+jobs:
+  lint-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap Lua toolchain
+        run: ./scripts/ensure-quality.sh --bootstrap-only
+
+      - name: Run stylua and luacheck checks
+        run: |
+          export PATH="$HOME/.luarocks/bin:$HOME/.local/bin:$PATH"
+          make quality:check

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,69 @@
 std = "lua51"
-globals = {
-  "ZO_SavedVars","EVENT_MANAGER","SLASH_COMMANDS",
-  "LibAddonMenu2","d","ZO_CreateStringId"
+max_line_length = 120
+unused_args = false
+unused_function = false
+allow_defined_top = true
+
+exclude_files = {
+  "reference/**",
+  "tools/**",
+  ".github/**",
+  "Nvk3UT-Release.zip",
 }
-ignore = { "111" } -- undefined field (bei ESO-APIs oft ok)
+
+read_globals = {
+  "Nvk3UT",
+  "Nvk3UT_*",
+  "ZO_*",
+  "LibStub",
+  "EVENT_MANAGER",
+  "EVENT_*",
+  "SCENE_MANAGER",
+  "SCENE_FRAGMENT_MANAGER",
+  "HUD_SCENE",
+  "HUD_UI_SCENE",
+  "KEYBINDING_MANAGER",
+  "CHAT_SYSTEM",
+  "SLASH_COMMANDS",
+  "QUEST_TRACKER",
+  "QUEST_JOURNAL_MANAGER",
+  "CUSTOM_TOOLTIP",
+  "SecurePostHook",
+  "zo_callLater",
+  "zo_strformat",
+  "zo_iconFormat",
+  "zo_loadstring",
+  "ZO_CreateStringId",
+  "GetFrameTimeMilliseconds",
+  "GetGameTimeMilliseconds",
+  "GetSecondsSinceMidnight",
+  "GetTimeStamp",
+  "GetUnitDisplayName",
+  "GetUnitName",
+  "GetNumJournalQuests",
+  "GetJournalQuestLocationInfo",
+  "GetJournalQuestName",
+  "GetJournalQuestType",
+  "GetJournalQuestRepeatType",
+  "GetJournalQuestStepInfo",
+  "GetJournalQuestConditionInfo",
+  "GetNumJournalQuestConditions",
+  "GetNumJournalQuestSteps",
+  "GetAchievementInfo",
+  "GetAchievementRewardItemLink",
+  "GetAchievementCategoryInfo",
+  "GetAchievementCategoryInfoFromCategoryId",
+  "GetAchievementNumCriteria",
+  "GetAchievementCriterion",
+  "GetAchievementNumRewards",
+  "GetCompletedAchievementInfo",
+  "GetCompletedQuestInfo",
+  "GetCompletedQuestLocationInfo",
+  "GetTrackingInfo",
+  "GetTrackedIsAssisted",
+  "GetTrackedQuestLocation",
+  "IsInGamepadPreferredMode",
+  "GetCVar",
+  "SetCVar",
+  "d",
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,17 +44,74 @@ These archives contain **third-party addons and example implementations** used *
 ---
 
 ## 🧠 Behavior and Commit Policy
-- Each Pull Request must reference a corresponding GitHub Issue (e.g., `Fixes #7`).  
-- Commits should have **short, descriptive messages** (e.g., `Add tooltip progress tracking`, `Fix multi-stage achievement detection`).  
-- Debugging code or logs must be **flagged or wrapped** under a global debug condition.  
+- Each Pull Request must reference a corresponding GitHub Issue (e.g., `Fixes #7`).
+- Commits should have **short, descriptive messages** (e.g., `Add tooltip progress tracking`, `Fix multi-stage achievement detection`).
+- Debugging code or logs must be **flagged or wrapped** under a global debug condition.
 - The agent should always **test locally** (where possible) before committing.
 
 ---
 
+## 🛠 Sandbox Bootstrap
+To lint or format Lua code, ensure the sandbox has Lua, Luarocks, `luacheck`, and `stylua` available. The process is idempotent and can be executed as often as needed:
+
+1. Run `./scripts/ensure-quality.sh --bootstrap-only` from the repository root. The script installs `lua5.4`, `luarocks`, `luacheck`, and the latest pinned StyLua release (Linux x86_64) using `apt-get`, `luarocks`, and GitHub binary downloads.
+2. The script automatically places tooling under `~/.luarocks/bin` and `~/.local/bin`. Ensure these directories stay on `PATH` for subsequent shells. The script exports them for its runtime; add `export PATH="$HOME/.luarocks/bin:$HOME/.local/bin:$PATH"` to reuse the tooling manually.
+3. The installer detects existing tools and skips re-installation, so it is safe to rerun between tasks or CI jobs.
+
+Refer to [`scripts/ensure-quality.sh`](scripts/ensure-quality.sh) for the definitive bootstrap sequence.
+
+---
+
+## ✅ Quality Standards (Mandatory)
+- **Formatting**: StyLua must be executed with the repository `stylua.toml`. In CI/PR contexts run `stylua --check` (read-only). Locally run the fix mode (`stylua` without `--check`) before committing.
+- **Linting**: `luacheck` must pass across the full addon tree using the project `.luacheckrc` configuration.
+- **Blocking rule**: *Do not open or update a PR while either check is failing.* Every contribution must keep both checks green.
+
+---
+
+## 👩‍💻 Developer Commands
+Standardized commands are provided via the repository `Makefile` and bootstrap script:
+
+| Action | Check Mode | Fix Mode |
+| --- | --- | --- |
+| Format | `make format:check` | `make format:fix` or `./scripts/ensure-quality.sh --fix` |
+| Lint | `make lint` | N/A (luacheck has no auto-fix; resolve findings manually) |
+| All quality checks | `make quality:check` | `./scripts/ensure-quality.sh --fix` (formats, then lints) |
+
+Always execute `./scripts/ensure-quality.sh --bootstrap-only` at least once per sandbox session to install toolchain dependencies. The script without flags (`./scripts/ensure-quality.sh`) installs missing tools and runs the check workflow (`stylua --check` followed by `luacheck`).
+
+---
+
+## 📋 Pre-PR Checklist
+Before pushing or opening a Pull Request ensure **every** item below is green:
+
+- [ ] `stylua --check` (or `make format:check`) passes without changes.
+- [ ] `luacheck` (or `make lint`) reports no errors.
+- [ ] Optional but encouraged: run addon smoke tests/build scripts (`make quality:check` already chains format+lint).
+
+If any checkbox would be red, *do not* raise the PR until it is resolved.
+
+---
+
+## 🤖 CI Enforcement
+A dedicated GitHub Actions workflow (`.github/workflows/lua-quality.yml`) runs on every `pull_request`. It bootstraps the Lua toolchain via `scripts/ensure-quality.sh --bootstrap-only`, then executes `make quality:check`. The PR is automatically blocked when either `stylua --check` or `luacheck` fails.
+
+---
+
+## ⚙️ Configuration & Support Files
+- [`.luacheckrc`](.luacheckrc): project-specific lint configuration covering ESO globals, maximum line width, and ignored directories.
+- [`stylua.toml`](stylua.toml): canonical formatting rules (column width, indentation, quoting, line endings).
+- [`Makefile`](Makefile): shared developer targets (`bootstrap`, `lint`, `format:check`, `format:fix`, `quality:check`).
+- [`scripts/ensure-quality.sh`](scripts/ensure-quality.sh): idempotent bootstrapper plus combined quality checks/fix workflow.
+- [`.github/workflows/lua-quality.yml`](.github/workflows/lua-quality.yml): CI gate enforcing StyLua and Luacheck for pull requests.
+- Optional ergonomics: add a local Git `pre-commit` hook that calls `make quality:check` to catch regressions before committing.
+
+---
+
 ## 🚫 Prohibited Actions
-- ❌ Do **not** copy or reuse code directly from any ZIP file in the `reference` folder.  
-- ❌ Do **not** extract or import files from those ZIPs into this repository.  
-- ❌ Do **not** fetch external code from the internet without explicit instruction.  
+- ❌ Do **not** copy or reuse code directly from any ZIP file in the `reference` folder.
+- ❌ Do **not** extract or import files from those ZIPs into this repository.
+- ❌ Do **not** fetch external code from the internet without explicit instruction.
 - ❌ Prefer safe hooks (ZO_PreHook/ZO_PostHook). However, when functional parity with the base tracker requires it, the agent **may override or replace** specific basegame handlers (e.g., default tracker visibility/fragment wiring). Such overrides must be minimal, documented, and limited in scope.
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: bootstrap lint format:check format:fix quality:check
+
+STYLUA ?= stylua
+LUACHECK ?= luacheck
+PROJECT_ROOT := $(CURDIR)
+
+bootstrap:
+./scripts/ensure-quality.sh --bootstrap-only
+
+lint:
+$(LUACHECK) $(PROJECT_ROOT)
+
+format:check:
+$(STYLUA) --config-path $(PROJECT_ROOT)/stylua.toml --check $(PROJECT_ROOT)
+
+format:fix:
+$(STYLUA) --config-path $(PROJECT_ROOT)/stylua.toml $(PROJECT_ROOT)
+
+quality:check: format:check lint

--- a/scripts/ensure-quality.sh
+++ b/scripts/ensure-quality.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.luarocks/bin:$HOME/.local/bin:$PATH"
+
+ensure_lua() {
+  if command -v lua >/dev/null 2>&1; then
+    return
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    local sudo_cmd=""
+    if command -v sudo >/dev/null 2>&1; then
+      sudo_cmd="sudo"
+    fi
+    echo "[ensure-quality] Installing lua5.4 via apt-get" >&2
+    if ! $sudo_cmd apt-get update -y >/dev/null; then
+      echo "[ensure-quality] Failed to update package lists; retry later or install Lua manually." >&2
+      exit 1
+    fi
+    if ! $sudo_cmd apt-get install -y lua5.4 >/dev/null; then
+      echo "[ensure-quality] Failed to install lua5.4; install it manually and re-run." >&2
+      exit 1
+    fi
+  else
+    echo "[ensure-quality] Missing lua5.4 and no package manager available; install Lua manually." >&2
+    exit 1
+  fi
+}
+
+ensure_luarocks() {
+  if command -v luarocks >/dev/null 2>&1; then
+    return
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    local sudo_cmd=""
+    if command -v sudo >/dev/null 2>&1; then
+      sudo_cmd="sudo"
+    fi
+    echo "[ensure-quality] Installing luarocks" >&2
+    if ! $sudo_cmd apt-get update -y >/dev/null; then
+      echo "[ensure-quality] Failed to update package lists; retry later or install Luarocks manually." >&2
+      exit 1
+    fi
+    if ! $sudo_cmd apt-get install -y luarocks >/dev/null; then
+      echo "[ensure-quality] Failed to install Luarocks; install it manually and re-run." >&2
+      exit 1
+    fi
+  else
+    echo "[ensure-quality] Missing luarocks and no package manager available; install Luarocks manually." >&2
+    exit 1
+  fi
+}
+
+ensure_luacheck() {
+  if command -v luacheck >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "[ensure-quality] Installing luacheck via luarocks" >&2
+  if ! luarocks install luacheck --local >/dev/null; then
+    echo "[ensure-quality] Failed to install luacheck; check your network connection or install it manually." >&2
+    exit 1
+  fi
+}
+
+ensure_stylua() {
+  if command -v stylua >/dev/null 2>&1; then
+    return
+  fi
+
+  local version
+  version=${STYLUA_VERSION:-0.20.0}
+  local archive="stylua-linux-x86_64.zip"
+  local url="https://github.com/JohnnyMorganz/StyLua/releases/download/v${version}/${archive}"
+  local bin_dir="$HOME/.local/bin"
+
+  mkdir -p "$bin_dir"
+
+  echo "[ensure-quality] Installing stylua ${version} from ${url}" >&2
+  if ! command -v curl >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+      local sudo_cmd=""
+      if command -v sudo >/dev/null 2>&1; then
+        sudo_cmd="sudo"
+      fi
+      if ! $sudo_cmd apt-get update -y >/dev/null; then
+        echo "[ensure-quality] Failed to update package lists; install curl manually." >&2
+        exit 1
+      fi
+      if ! $sudo_cmd apt-get install -y curl >/dev/null; then
+        echo "[ensure-quality] Failed to install curl; install it manually." >&2
+        exit 1
+      fi
+    else
+      echo "[ensure-quality] curl is required to download stylua; install it manually." >&2
+      exit 1
+    fi
+  fi
+
+  if ! command -v unzip >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+      local sudo_cmd=""
+      if command -v sudo >/dev/null 2>&1; then
+        sudo_cmd="sudo"
+      fi
+      if ! $sudo_cmd apt-get update -y >/dev/null; then
+        echo "[ensure-quality] Failed to update package lists; install unzip manually." >&2
+        exit 1
+      fi
+      if ! $sudo_cmd apt-get install -y unzip >/dev/null; then
+        echo "[ensure-quality] Failed to install unzip; install it manually." >&2
+        exit 1
+      fi
+    else
+      echo "[ensure-quality] unzip is required to install stylua; install it manually." >&2
+      exit 1
+    fi
+  fi
+
+  local tmp
+  tmp=$(mktemp -d)
+  if ! curl -sSL "$url" -o "$tmp/${archive}"; then
+    echo "[ensure-quality] Failed to download stylua ${version}; check your network connection." >&2
+    exit 1
+  fi
+  if ! unzip -oq "$tmp/${archive}" -d "$tmp"; then
+    echo "[ensure-quality] Failed to extract the stylua archive." >&2
+    exit 1
+  fi
+  mv -f "$tmp/stylua" "$bin_dir/stylua"
+  chmod +x "$bin_dir/stylua"
+  rm -rf "$tmp"
+}
+
+run_stylua_check() {
+  echo "[ensure-quality] Running stylua --check" >&2
+  stylua --config-path "$PROJECT_ROOT/stylua.toml" --check "$PROJECT_ROOT"
+}
+
+run_stylua_fix() {
+  echo "[ensure-quality] Running stylua (format)" >&2
+  stylua --config-path "$PROJECT_ROOT/stylua.toml" "$PROJECT_ROOT"
+}
+
+run_luacheck() {
+  echo "[ensure-quality] Running luacheck" >&2
+  luacheck "$PROJECT_ROOT"
+}
+
+RUN_CHECKS=1
+RUN_FIX=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bootstrap-only)
+      RUN_CHECKS=0
+      ;;
+    --fix)
+      RUN_FIX=1
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+ensure_lua
+ensure_luarocks
+ensure_luacheck
+ensure_stylua
+
+if [[ $RUN_CHECKS -eq 1 ]]; then
+  if [[ $RUN_FIX -eq 1 ]]; then
+    run_stylua_fix
+  else
+    run_stylua_check
+  fi
+  run_luacheck
+fi

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,4 +1,6 @@
 column_width = 120
 indent_type = "Spaces"
 indent_width = 2
+line_endings = "Unix"
 quote_style = "AutoPreferDouble"
+call_parentheses = "Always"


### PR DESCRIPTION
## Summary
- document mandatory Lua linting and formatting requirements in `AGENTS.md`
- add luacheck and stylua configuration plus shared Makefile/script helpers
- enforce luacheck and stylua checks in CI via `lua-quality` workflow

## Testing
- ./scripts/ensure-quality.sh --bootstrap-only *(fails: apt repositories unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fb90978800832a9bb40cba256f0a17