### PR TITLE
Add quest tracker status segment

### DIFF
--- a/Nvk3UT_LAM.lua
+++ b/Nvk3UT_LAM.lua
@@ -960,6 +960,9 @@ local function registerPanel(displayTitle)
                     if Nvk3UT and Nvk3UT.QuestTracker and Nvk3UT.QuestTracker.SetActive then
                         Nvk3UT.QuestTracker.SetActive(value)
                     end
+                    if Nvk3UT and Nvk3UT.UI and Nvk3UT.UI.UpdateStatus then
+                        Nvk3UT.UI.UpdateStatus()
+                    end
                 end,
                 default = true,
             }

--- a/Nvk3UT_QuestTracker.lua
+++ b/Nvk3UT_QuestTracker.lua
@@ -191,6 +191,13 @@ local function NotifyHostContentChanged()
     pcall(host.NotifyContentChanged)
 end
 
+local function NotifyStatusRefresh()
+    local ui = Nvk3UT and Nvk3UT.UI
+    if ui and ui.UpdateStatus then
+        ui.UpdateStatus()
+    end
+end
+
 local function EnsureSavedVars()
     Nvk3UT.sv = Nvk3UT.sv or {}
     Nvk3UT.sv.QuestTracker = Nvk3UT.sv.QuestTracker or {}
@@ -721,6 +728,7 @@ local function OnSnapshotUpdated(snapshot)
     if state.isInitialized then
         Rebuild()
     end
+    NotifyStatusRefresh()
 end
 
 function QuestTracker.Init(parentControl, opts)
@@ -818,6 +826,7 @@ end
 function QuestTracker.SetActive(active)
     state.opts.active = active
     RefreshVisibility()
+    NotifyStatusRefresh()
 end
 
 function QuestTracker.ApplySettings(settings)
@@ -840,6 +849,7 @@ function QuestTracker.ApplySettings(settings)
 
     RefreshVisibility()
     RequestRefresh()
+    NotifyStatusRefresh()
 end
 
 function QuestTracker.ApplyTheme(settings)
@@ -857,6 +867,10 @@ function QuestTracker.ApplyTheme(settings)
     state.fonts = MergeFonts(state.opts.fonts)
 
     RequestRefresh()
+end
+
+function QuestTracker.IsActive()
+    return state.opts.active ~= false
 end
 
 function QuestTracker.RequestRefresh()


### PR DESCRIPTION
## Summary
- show quest tracker progress at the front of the status text when the tracker is active
- reuse the quest model snapshot (with API fallback) to keep quest counts in sync with the tracker
- refresh the status display when quest data or the quest tracker setting changes and expose QuestTracker.IsActive()

## Testing
- ./scripts/ensure-quality.sh --bootstrap-only *(fails: apt repositories return 403 so tooling could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68fb94c62ad0832a885028391da6386e