### PR TITLE
Always show enabled status counters

### DIFF
--- a/Nvk3UT_UI.lua
+++ b/Nvk3UT_UI.lua
@@ -219,23 +219,17 @@ local function __nvk3_BuildStatusParts()
 
   if __nvk3_IsOn("favorites") then
     local n = __nvk3_CountFavorites()
-    if n > 0 then
-      parts[#parts + 1] = ("Favoriten %d"):format(n)
-    end
+    parts[#parts + 1] = ("Favoriten %d"):format(n)
   end
 
   if __nvk3_IsOn("recent") then
     local n = __nvk3_CountRecent()
-    if n > 0 then
-      parts[#parts + 1] = ("Kürzlich %d"):format(n)
-    end
+    parts[#parts + 1] = ("Kürzlich %d"):format(n)
   end
 
   if __nvk3_IsOn("todo") then
     local n = __nvk3_CountTodo()
-    if n > 0 then
-      parts[#parts + 1] = ("To-Do-Liste %d"):format(n)
-    end
+    parts[#parts + 1] = ("To-Do-Liste %d"):format(n)
   end
 
   return parts


### PR DESCRIPTION
## Summary
- always include enabled favorites, recent, and to-do status segments even when their counts are zero

## Testing
- not run (not requested)

Fixes #123

------
https://chatgpt.com/codex/tasks/task_e_68fba5e51e18832aaad80fbffb2136f7