### PR TITLE
Fix achievement tracker alignment

### DIFF
--- a/Nvk3UT_AchievementTracker.lua
+++ b/Nvk3UT_AchievementTracker.lua
@@ -367,7 +367,9 @@ local function AnchorControl(control, indentX)
     control:ClearAnchors()
 
     if state.lastAnchoredControl then
-        control:SetAnchor(TOPLEFT, state.lastAnchoredControl, BOTTOMLEFT, indentX, VERTICAL_PADDING)
+        local previousIndent = state.lastAnchoredControl.currentIndent or 0
+        local offsetX = indentX - previousIndent
+        control:SetAnchor(TOPLEFT, state.lastAnchoredControl, BOTTOMLEFT, offsetX, VERTICAL_PADDING)
         control:SetAnchor(TOPRIGHT, state.lastAnchoredControl, BOTTOMRIGHT, 0, VERTICAL_PADDING)
     else
         control:SetAnchor(TOPLEFT, state.container, TOPLEFT, indentX, 0)


### PR DESCRIPTION
## Summary
- adjust achievement tracker anchoring so indentation changes match the quest tracker

## Testing
- not run (not available)

Fixes #0

------
https://chatgpt.com/codex/tasks/task_e_68fbbf8ec13c832ab3b5ad584847fe9a