### PR TITLE
Fix grammar tokens in achievement tracker

### DIFF
--- a/Nvk3UT_AchievementModel.lua
+++ b/Nvk3UT_AchievementModel.lua
@@ -67,6 +67,36 @@ local function SafeCallMulti(func, ...)
     return tableUnpack(results)
 end
 
+local function FormatDisplayString(text)
+    if text == nil then
+        return nil
+    end
+
+    if type(text) ~= "string" then
+        return text
+    end
+
+    if text == "" then
+        return ""
+    end
+
+    if type(ZO_CachedStrFormat) == "function" then
+        local ok, formatted = pcall(ZO_CachedStrFormat, "<<1>>", text)
+        if ok and formatted ~= nil then
+            return formatted
+        end
+    end
+
+    if type(zo_strformat) == "function" then
+        local ok, formatted = pcall(zo_strformat, "<<1>>", text)
+        if ok and formatted ~= nil then
+            return formatted
+        end
+    end
+
+    return text
+end
+
 local function NormalizeAchievementId(value)
     if type(value) == "number" then
         return value
@@ -122,6 +152,8 @@ local function BuildObjectiveData(achievementId)
             criterionIndex
         )
 
+        description = FormatDisplayString(description)
+
         objectives[#objectives + 1] = {
             description = description,
             current = numCompleted,
@@ -144,7 +176,7 @@ local function DetermineCategoryInfo(categoryIndex, subCategoryIndex, achievemen
     if GetAchievementCategoryInfo then
         local infoName = SafeCallMulti(GetAchievementCategoryInfo, categoryIndex)
         if infoName ~= nil then
-            categoryName = infoName
+            categoryName = FormatDisplayString(infoName)
         end
     end
 
@@ -152,7 +184,7 @@ local function DetermineCategoryInfo(categoryIndex, subCategoryIndex, achievemen
     if subCategoryIndex and GetAchievementSubCategoryInfo then
         local infoName = SafeCallMulti(GetAchievementSubCategoryInfo, categoryIndex, subCategoryIndex)
         if infoName ~= nil then
-            subCategoryName = infoName
+            subCategoryName = FormatDisplayString(infoName)
         end
     end
 
@@ -258,6 +290,9 @@ local function BuildAchievementEntry(self, achievementId)
             completedTimestamp = infoTimeStamp or infoDate
         end
     end
+
+    name = FormatDisplayString(name)
+    description = FormatDisplayString(description)
 
     local current
     local maximum

--- a/Nvk3UT_AchievementTracker.lua
+++ b/Nvk3UT_AchievementTracker.lua
@@ -19,6 +19,37 @@ local FormatCategoryHeaderText =
         return text
     end
 
+local function FormatDisplayString(text)
+    if text == nil then
+        return ""
+    end
+
+    local value = text
+    if type(value) ~= "string" then
+        value = tostring(value)
+    end
+
+    if value == "" then
+        return ""
+    end
+
+    if type(ZO_CachedStrFormat) == "function" then
+        local ok, formatted = pcall(ZO_CachedStrFormat, "<<1>>", value)
+        if ok and formatted ~= nil then
+            return formatted
+        end
+    end
+
+    if type(zo_strformat) == "function" then
+        local ok, formatted = pcall(zo_strformat, "<<1>>", value)
+        if ok and formatted ~= nil then
+            return formatted
+        end
+    end
+
+    return value
+end
+
 local CATEGORY_TOGGLE_TEXTURES = {
     expanded = {
         up = "EsoUI/Art/Buttons/tree_open_up.dds",
@@ -1085,7 +1116,7 @@ local function UpdateAchievementIconSlot(control)
 end
 
 local function FormatObjectiveText(objective)
-    local description = objective.description or ""
+    local description = FormatDisplayString(objective.description)
     if description == "" then
         return ""
     end
@@ -1105,10 +1136,7 @@ local function FormatObjectiveText(objective)
         text = description
     end
 
-    if zo_strformat then
-        return zo_strformat("<<1>>", text)
-    end
-    return text
+    return FormatDisplayString(text)
 end
 
 local function ShouldDisplayObjective(objective)
@@ -1335,7 +1363,7 @@ local function LayoutAchievement(achievement)
         hasObjectives = hasObjectives,
         isFavorite = isFavorite,
     }
-    control.label:SetText(achievement.name or "")
+    control.label:SetText(FormatDisplayString(achievement.name))
     local r, g, b, a = GetAchievementTrackerColor("entryTitle")
     ApplyBaseColor(control, r, g, b, a)
 


### PR DESCRIPTION
## Summary
- format achievement names, descriptions, categories, and criteria via the ESO string formatter when building tracker data
- ensure tracker labels use the formatted strings so player grammar tokens resolve correctly

## Testing
- not run (UI changes only)

Fixes #123

------
https://chatgpt.com/codex/tasks/task_e_68fe16de3858832a9d459e7b2af9da88