### PR TITLE
Add quest tracker state persistence store

### DIFF
--- a/Core/Nvk3UT_StateInit.lua
+++ b/Core/Nvk3UT_StateInit.lua
@@ -221,6 +221,33 @@ function Nvk3UT_StateInit.BootstrapSavedVariables(addonTable)
 
     addonTable.SV = sv
     addonTable.sv = sv
+    addonTable.db = sv
+
+    local db = addonTable.db
+
+    db.QuestState = db.QuestState or {}
+    local qs = db.QuestState
+
+    qs.version = qs.version or 1
+
+    qs.window = qs.window or {}
+    qs.window.x = qs.window.x or 100
+    qs.window.y = qs.window.y or 100
+    qs.window.locked = (qs.window.locked == nil) and false or qs.window.locked
+
+    qs.expanded = qs.expanded or {}
+    qs.expanded.quests = qs.expanded.quests or {}
+    qs.expanded.quests_ts = qs.expanded.quests_ts or {}
+    qs.expanded.categories = qs.expanded.categories or {}
+    qs.expanded.categories_ts = qs.expanded.categories_ts or {}
+
+    if Nvk3UT.QuestState and Nvk3UT.QuestState.Init then
+        if Nvk3UT.SafeCall then
+            Nvk3UT.SafeCall(Nvk3UT.QuestState.Init, Nvk3UT.QuestState, db)
+        else
+            Nvk3UT.QuestState:Init(db)
+        end
+    end
 
     if type(addonTable.SetDebugEnabled) == "function" then
         addonTable:SetDebugEnabled(sv.debug)

--- a/Model/Quest/Nvk3UT_QuestState.lua
+++ b/Model/Quest/Nvk3UT_QuestState.lua
@@ -1,0 +1,126 @@
+local addon = Nvk3UT
+local M = {}
+addon.QuestState = M
+
+function M:Init(db)
+    self.db = db
+    self.sv = db.QuestState or {}
+    if addon.Diagnostics and addon.Diagnostics.Debug then
+        addon.Diagnostics:Debug("QuestState.Init() ok")
+    end
+end
+
+function M:GetWindowPosition()
+    local w = self.sv.window or {}
+    return w.x, w.y
+end
+
+function M:SetWindowPosition(x, y)
+    local w = self.sv.window
+    if type(w) ~= "table" then
+        return
+    end
+
+    if type(x) == "number" and type(y) == "number" then
+        w.x, w.y = x, y
+    end
+end
+
+function M:IsWindowLocked()
+    local w = self.sv.window
+    return type(w) == "table" and w.locked == true
+end
+
+function M:SetWindowLocked(locked)
+    local w = self.sv.window
+    if type(w) ~= "table" then
+        return
+    end
+
+    self.sv.window.locked = locked and true or false
+end
+
+function M:IsQuestExpanded(questId)
+    local quests = self.sv.expanded and self.sv.expanded.quests
+    return type(quests) == "table" and quests[questId] == true
+end
+
+function M:SetQuestExpanded(questId, expanded, source)
+    local expandedMap = self.sv.expanded and self.sv.expanded.quests
+    local tsMap = self.sv.expanded and self.sv.expanded.quests_ts
+    if type(expandedMap) ~= "table" or type(tsMap) ~= "table" then
+        return
+    end
+
+    expandedMap[questId] = (expanded and true) or false
+    tsMap[questId] = GetTimeStamp()
+
+    if addon.Diagnostics and addon.Diagnostics.Debug then
+        addon.Diagnostics:Debug(("QuestState: qid=%s expanded=%s src=%s"):format(
+            tostring(questId),
+            tostring(expanded),
+            tostring(source)
+        ))
+    end
+end
+
+function M:PruneUnknownQuests(validQuestIdsSet)
+    local expandedMap = self.sv.expanded and self.sv.expanded.quests
+    local tsMap = self.sv.expanded and self.sv.expanded.quests_ts
+    if type(expandedMap) ~= "table" or type(tsMap) ~= "table" then
+        return
+    end
+
+    if type(validQuestIdsSet) ~= "table" then
+        return
+    end
+
+    for questId in pairs(expandedMap) do
+        if not validQuestIdsSet[questId] then
+            expandedMap[questId] = nil
+            tsMap[questId] = nil
+        end
+    end
+end
+
+function M:IsCategoryExpanded(categoryKey)
+    local categories = self.sv.expanded and self.sv.expanded.categories
+    return type(categories) == "table" and categories[categoryKey] == true
+end
+
+function M:SetCategoryExpanded(categoryKey, expanded, source)
+    local categories = self.sv.expanded and self.sv.expanded.categories
+    local tsMap = self.sv.expanded and self.sv.expanded.categories_ts
+    if type(categories) ~= "table" or type(tsMap) ~= "table" then
+        return
+    end
+
+    categories[categoryKey] = (expanded and true) or false
+    tsMap[categoryKey] = GetTimeStamp()
+
+    if addon.Diagnostics and addon.Diagnostics.Debug then
+        addon.Diagnostics:Debug(("QuestState: cat=%s expanded=%s src=%s"):format(
+            tostring(categoryKey),
+            tostring(expanded),
+            tostring(source)
+        ))
+    end
+end
+
+function M:ResetAll()
+    local window = self.sv.window
+    local expanded = self.sv.expanded
+    if type(window) ~= "table" or type(expanded) ~= "table" then
+        return
+    end
+
+    window.x, window.y = 100, 100
+    window.locked = false
+
+    expanded.quests = {}
+    expanded.quests_ts = {}
+    expanded.categories = {}
+    expanded.categories_ts = {}
+end
+
+return M

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -25,6 +25,7 @@ Nvk3UT_TodoData.lua
 Nvk3UT_TodoIntegration.lua
 Nvk3UT_CompletedData.lua
 Nvk3UT_CompletedIntegration.lua
+Model/Quest/Nvk3UT_QuestState.lua
 Nvk3UT_QuestModel.lua
 Nvk3UT_AchievementModel.lua
 Nvk3UT_QuestTracker.xml


### PR DESCRIPTION
## Summary
- add a QuestState module to manage per-quest, category, and window persistence
- seed QuestState defaults during saved variable initialization and safely init the module
- register the new quest state file in the addon manifest

## Testing
- stylua --check Model/Quest/Nvk3UT_QuestState.lua Core/Nvk3UT_StateInit.lua *(fails: command not found)*
- luacheck Model/Quest/Nvk3UT_QuestState.lua Core/Nvk3UT_StateInit.lua *(fails: command not found)*

Fixes #1

------
https://chatgpt.com/codex/tasks/task_e_6903a08a7a94832abe8a74979db16a3d