### PR TITLE
Route quest tracker bindings to quest data storage

### DIFF
--- a/Model/Quest/Nvk3UT_QuestModel.lua
+++ b/Model/Quest/Nvk3UT_QuestModel.lua
@@ -518,6 +518,10 @@ function QuestModel.Shutdown()
     ResetBaseCategoryCache()
 end
 
+function QuestModel.GetSavedVars()
+    return questSavedVars
+end
+
 function QuestModel.GetSnapshot()
     return QuestModel.currentSnapshot
 end

--- a/Nvk3UT_QuestTracker.lua
+++ b/Nvk3UT_QuestTracker.lua
@@ -2571,19 +2571,24 @@ end
 local function EnsureSavedVars()
     Nvk3UT.sv = Nvk3UT.sv or {}
 
+    local questRoot =
+        (Nvk3UT.QuestModel and Nvk3UT.QuestModel.GetSavedVars and Nvk3UT.QuestModel.GetSavedVars())
+        or Nvk3UT.sv
+
     if QuestState and QuestState.Bind then
-        local saved = QuestState.Bind(Nvk3UT.sv)
+        local saved = QuestState.Bind(questRoot)
         state.saved = saved
         if QuestSelection and QuestSelection.Bind then
-            QuestSelection.Bind(Nvk3UT.sv, saved)
+            QuestSelection.Bind(questRoot, saved)
         end
     else
-        local saved = Nvk3UT.sv.QuestTracker or {}
-        Nvk3UT.sv.QuestTracker = saved
+        local root = questRoot or Nvk3UT.sv or {}
+        local saved = root.QuestTracker or {}
+        root.QuestTracker = saved
         state.saved = saved
         EnsureActiveSavedState()
         if QuestSelection and QuestSelection.Bind then
-            QuestSelection.Bind(Nvk3UT.sv, saved)
+            QuestSelection.Bind(root, saved)
         end
     end
 


### PR DESCRIPTION
## Summary
- expose `QuestModel.GetSavedVars` so external modules can access the quest saved variables root
- bind quest tracker state helpers against the quest data saved variables instead of `Nvk3UT.sv`

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121a219ef4832ab0a74c45b15954e4)