### PR TITLE
Add Endeavor tracker font groups and apply per-row fonts

### DIFF
--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Favorites category + context menu; 'Kürzlich' as its own category with same icon; Status + LAM.
 ## Author: Nvk3
-## Version: 0.11.4
-## AddOnVersion: 1104
+## Version: 0.11.5
+## AddOnVersion: 1105
 ## APIVersion: 101041 101042 101043
 ## DependsOn: LibAddonMenu-2.0
 ## OptionalDependsOn: LibCustomMenu-2.0


### PR DESCRIPTION
## Summary
- add saved variable defaults for Endeavor tracker fonts and mirror legacy settings into the new structure
- expose separate Category/Title/Objective font controls in the Endeavor LAM section by reusing the shared font helpers
- update the Endeavor tracker controller and rows so category headers, section titles, and objective lines render with the configured fonts immediately

## Testing
- no automated tests were run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b06f66a8832aaf8a2b27a62b1549)