### PR TITLE
EUI_001C_Enable_EntryPooling — Reuse objective rows in Endeavor tracker

### DIFF
--- a/Tracker/Endeavor/Nvk3UT_EndeavorTracker.lua
+++ b/Tracker/Endeavor/Nvk3UT_EndeavorTracker.lua
@@ -1543,8 +1543,15 @@ function EndeavorTracker.Refresh(viewModel)
             end
 
             if rows then
+                if type(rows.ResetEntryPool) == "function" then
+                    rows.ResetEntryPool()
+                end
+
                 if dailyObjectivesControl then
                     if dailyExpanded and type(rows.BuildObjectives) == "function" then
+                        if type(rows.ResetEntryPool) == "function" then
+                            rows.ResetEntryPool(dailyObjectivesControl)
+                        end
                         rows.BuildObjectives(dailyObjectivesControl, dailyObjectivesList, rowsOptions)
                         dailyObjectivesControl:SetHidden(false)
                     else
@@ -1561,6 +1568,9 @@ function EndeavorTracker.Refresh(viewModel)
 
                 if weeklyObjectivesControl then
                     if weeklyExpanded and type(rows.BuildObjectives) == "function" then
+                        if type(rows.ResetEntryPool) == "function" then
+                            rows.ResetEntryPool(weeklyObjectivesControl)
+                        end
                         rows.BuildObjectives(weeklyObjectivesControl, weeklyObjectivesList, rowsOptions)
                         weeklyObjectivesControl:SetHidden(false)
                     else


### PR DESCRIPTION
## Summary
- add an entry row pool with acquire/release/reset helpers and centralized ApplyEntryRow logic in the Endeavor tracker rows module
- update the Endeavor tracker refresh flow to reset and acquire entry rows from the pool before building daily and weekly objectives

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d3b27568832aa343000228d4e6eb)