### PR TITLE
Endeavor: implement cap handling (hide/recolor) with full section collapse when both caps reached

### DIFF
--- a/Model/Endeavor/Nvk3UT_EndeavorModel.lua
+++ b/Model/Endeavor/Nvk3UT_EndeavorModel.lua
@@ -665,6 +665,82 @@ function EndeavorModel:GetSummary()
     }
 end
 
+local function isCapReached(completed, limit)
+    local completedValue = tonumber(completed) or 0
+    if completedValue < 0 then
+        completedValue = 0
+    end
+
+    local limitValue = tonumber(limit) or 0
+    if limitValue <= 0 then
+        return false
+    end
+
+    if limitValue < 0 then
+        limitValue = 0
+    end
+
+    return completedValue >= limitValue
+end
+
+function EndeavorModel:IsDailyCapped()
+    local summary = self._summary
+    if type(summary) ~= "table" then
+        summary = self:GetSummary()
+    end
+
+    local completed = summary and summary.dailyCompleted
+    local limit = summary and summary.dailyLimit
+
+    if summary == self._summary then
+        completed = summary.dailyCompleted or 0
+        limit = summary.dailyLimit or 0
+    end
+
+    if isCapReached(completed, limit) then
+        return true
+    end
+
+    local snapshot = self._snapshot
+    if type(snapshot) == "table" then
+        local daily = snapshot.daily
+        if type(daily) == "table" then
+            return isCapReached(daily.completed, daily.limit)
+        end
+    end
+
+    return false
+end
+
+function EndeavorModel:IsWeeklyCapped()
+    local summary = self._summary
+    if type(summary) ~= "table" then
+        summary = self:GetSummary()
+    end
+
+    local completed = summary and summary.weeklyCompleted
+    local limit = summary and summary.weeklyLimit
+
+    if summary == self._summary then
+        completed = summary.weeklyCompleted or 0
+        limit = summary.weeklyLimit or 0
+    end
+
+    if isCapReached(completed, limit) then
+        return true
+    end
+
+    local snapshot = self._snapshot
+    if type(snapshot) == "table" then
+        local weekly = snapshot.weekly
+        if type(weekly) == "table" then
+            return isCapReached(weekly.completed, weekly.limit)
+        end
+    end
+
+    return false
+end
+
 function EndeavorModel:GetCountsForDebug()
     if type(self._snapshot) ~= "table" then
         return {

--- a/Runtime/Nvk3UT_TrackerHostLayout.lua
+++ b/Runtime/Nvk3UT_TrackerHostLayout.lua
@@ -801,7 +801,30 @@ function Layout.ApplyLayout(host, sizes)
             reportMissing(host, sectionId)
         else
             local _, height = measureSection(host, sectionId, container)
+            local isEndeavorSection = sectionId == "endeavor"
+            local collapsed = isEndeavorSection and height <= 0
+
+            if isEndeavorSection and container then
+                if collapsed then
+                    if container.SetHeight then
+                        container:SetHeight(0)
+                    end
+                    if container.SetHidden then
+                        container:SetHidden(true)
+                    end
+                    container._nvk3utAutoHidden = true
+                elseif container._nvk3utAutoHidden then
+                    if container.SetHidden then
+                        container:SetHidden(false)
+                    end
+                    container._nvk3utAutoHidden = nil
+                end
+            end
+
             local sectionVisible = not isControlHidden(container)
+            if collapsed then
+                sectionVisible = false
+            end
 
             if sectionVisible then
                 local predictedBottom = currentTop + height

--- a/Tracker/Endeavor/Nvk3UT_EndeavorTrackerLayout.lua
+++ b/Tracker/Endeavor/Nvk3UT_EndeavorTrackerLayout.lua
@@ -150,6 +150,36 @@ function Layout.Apply(container, context)
 
     local data = type(context) == "table" and context or {}
 
+    local sectionEntry = type(data.section) == "table" and data.section or {}
+    local hideEntireSection = sectionEntry.hideEntireSection == true
+
+    if hideEntireSection then
+        if container then
+            if container.SetHidden then
+                container:SetHidden(true)
+            end
+            if container.SetHeight then
+                container:SetHeight(0)
+            end
+            if container.SetDimensions then
+                local width
+                if container.GetWidth then
+                    local ok, currentWidth = pcall(container.GetWidth, container)
+                    if ok and type(currentWidth) == "number" then
+                        width = currentWidth
+                    end
+                end
+                if type(width) == "number" and width > 0 then
+                    container:SetDimensions(width, 0)
+                end
+            end
+        end
+
+        lastHeight = 0
+        safeDebug("EndeavorTrackerLayout.Apply: hidden section (height=0)")
+        return 0
+    end
+
     local categoryEntry = type(data.category) == "table" and data.category or {}
     local categoryControl = categoryEntry.control
     if categoryControl then
@@ -160,37 +190,45 @@ function Layout.Apply(container, context)
 
     local dailyEntry = type(data.daily) == "table" and data.daily or {}
     local dailyControl = dailyEntry.control
+    local dailyHidden = dailyEntry.hideRow == true
+    local dailyObjectivesHidden = dailyEntry.hideObjectives == true
     local dailyObjectivesEntry = type(data.dailyObjectives) == "table" and data.dailyObjectives or {}
     local dailyObjectivesControl = dailyObjectivesEntry.control
 
     local weeklyEntry = type(data.weekly) == "table" and data.weekly or {}
     local weeklyControl = weeklyEntry.control
+    local weeklyHidden = weeklyEntry.hideRow == true
+    local weeklyObjectivesHidden = weeklyEntry.hideObjectives == true
     local weeklyObjectivesEntry = type(data.weeklyObjectives) == "table" and data.weeklyObjectives or {}
     local weeklyObjectivesControl = weeklyObjectivesEntry.control
 
     if categoryExpanded then
-        if dailyControl then
+        if dailyControl and not dailyHidden then
             addControl(dailyControl, SECTION_ROW_HEIGHT, "row")
         end
 
-        if dailyObjectivesControl then
+        if dailyObjectivesControl and not dailyHidden and not dailyObjectivesHidden then
             if shouldExpand(dailyObjectivesEntry) then
                 addControl(dailyObjectivesControl, 0, "row")
             elseif dailyObjectivesControl.SetHidden then
                 dailyObjectivesControl:SetHidden(true)
             end
+        elseif dailyObjectivesControl and dailyObjectivesControl.SetHidden then
+            dailyObjectivesControl:SetHidden(true)
         end
 
-        if weeklyControl then
+        if weeklyControl and not weeklyHidden then
             addControl(weeklyControl, SECTION_ROW_HEIGHT, "row")
         end
 
-        if weeklyObjectivesControl then
+        if weeklyObjectivesControl and not weeklyHidden and not weeklyObjectivesHidden then
             if shouldExpand(weeklyObjectivesEntry) then
                 addControl(weeklyObjectivesControl, 0, "row")
             elseif weeklyObjectivesControl.SetHidden then
                 weeklyObjectivesControl:SetHidden(true)
             end
+        elseif weeklyObjectivesControl and weeklyObjectivesControl.SetHidden then
+            weeklyObjectivesControl:SetHidden(true)
         end
     else
         if dailyControl and dailyControl.SetHidden then

--- a/Tracker/Endeavor/Nvk3UT_EndeavorTrackerRows.lua
+++ b/Tracker/Endeavor/Nvk3UT_EndeavorTrackerRows.lua
@@ -66,6 +66,7 @@ local DEFAULT_FONT_OUTLINE = "soft-shadow-thick"
 local DEFAULT_OBJECTIVE_COLOR_ROLE = "objectiveText"
 local DEFAULT_TRACKER_COLOR_KIND = "endeavorTracker"
 local COMPLETED_COLOR_ROLE = "completed"
+local ENTRY_COLOR_ROLE = "entryTitle"
 local OBJECTIVE_INDENT_X = 60
 
 local SUBROW_ICON_SIZE = 16
@@ -1598,6 +1599,38 @@ local function applyObjectiveColor(label, options, objective)
     end
 end
 
+local function applyGroupLabelColor(label, options, useCompletedStyle)
+    if not label or not label.SetColor then
+        return false
+    end
+
+    local opts = type(options) == "table" and options or {}
+    local colors = type(opts.colors) == "table" and opts.colors or nil
+
+    local role
+    if useCompletedStyle then
+        role = opts.completedRole or COMPLETED_COLOR_ROLE
+    else
+        role = opts.entryRole or ENTRY_COLOR_ROLE
+    end
+
+    local r, g, b, a
+    if colors then
+        r, g, b, a = extractColorComponents(colors[role])
+    end
+
+    if r == nil then
+        r, g, b, a = getTrackerColor(role, opts.colorKind or DEFAULT_TRACKER_COLOR_KIND)
+    end
+
+    label:SetColor(r or 1, g or 1, b or 1, a or 1)
+    if label.SetAlpha then
+        label:SetAlpha(1)
+    end
+
+    return true
+end
+
 local function applyEntryRow(row, objective, options)
     if row == nil then
         return
@@ -1726,6 +1759,10 @@ end
 
 function Rows.ApplyEntryRow(row, objective, options)
     applyEntryRow(row, objective, options)
+end
+
+function Rows.ApplyGroupLabelColor(label, options, useCompletedStyle)
+    return applyGroupLabelColor(label, options, useCompletedStyle == true)
 end
 
 function Rows.Init()


### PR DESCRIPTION
## Summary
- add daily/weekly cap getters to the Endeavor model and surface cap state & hide flags in the tracker view model
- update tracker rendering/layout to hide or recolor rows and objectives per LAM setting, collapsing the section when both caps are hit
- extend rows and host layout helpers to apply completed colors, skip hidden content, and fully remove section spacing when collapsed

## Testing
- not run (UI logic only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f23820c0832a85332070d50e2fec)