### PR TITLE
Ensure LAM toggles trigger full tracker rebuilds

### DIFF
--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Favorites category + context menu; 'Kürzlich' as its own category with same icon; Status + LAM.
 ## Author: Nvk3
-## Version: 0.11.14
-## AddOnVersion: 1114
+## Version: 0.11.15
+## AddOnVersion: 1115
 ## APIVersion: 101041 101042 101043
 ## DependsOn: LibAddonMenu-2.0
 ## OptionalDependsOn: LibCustomMenu-2.0


### PR DESCRIPTION
## Summary
- add a LamQueueFullRebuild helper and route Quest/Achievement tracker visibility toggles through the centralized rebuild path
- wire Endeavor enable/completed handling options to the rebuild system and bump the addon manifest version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919cb85f358832a95134ae8297f2c63)