### PR TITLE
Fix scroll range calculation to use scroll container height

### DIFF
--- a/Runtime/Nvk3UT_TrackerHostLayout.lua
+++ b/Runtime/Nvk3UT_TrackerHostLayout.lua
@@ -739,20 +739,12 @@ function Layout.UpdateScrollAreaHeight(host, contentHeight, sizes)
         last.scrollChildHeight = scrollChildHeight
     end
 
-    local topY = sizes and sanitizeLength(sizes.contentTopY) or 0
-    local bottomY = sizes and tonumber(sizes.contentBottomY)
     local viewportHeight
 
-    if bottomY and bottomY ~= math.huge then
-        viewportHeight = bottomY - topY
-    end
-
-    if not viewportHeight or viewportHeight <= 0 then
-        if type(scrollContainer.GetHeight) == "function" then
-            local ok, height = pcall(scrollContainer.GetHeight, scrollContainer)
-            if ok then
-                viewportHeight = sanitizeLength(height)
-            end
+    if type(scrollContainer.GetHeight) == "function" then
+        local ok, height = pcall(scrollContainer.GetHeight, scrollContainer)
+        if ok then
+            viewportHeight = sanitizeLength(height)
         end
     end
 


### PR DESCRIPTION
## Summary
- calculate the scroll viewport height directly from the scroll container size while keeping existing scroll child sizing logic
- sanitize and clamp the computed viewport height to avoid negative ranges

## Testing
- Not run (not requested)

Fixes #0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af3deb4c4832a91aaa91d579bbe6e)