### PR TITLE
Add scroll viewport/range debug output to TrackerHost

### DIFF
--- a/Runtime/Nvk3UT_TrackerHost.lua
+++ b/Runtime/Nvk3UT_TrackerHost.lua
@@ -2592,11 +2592,23 @@ refreshScroll = function(targetOffset)
         tostring(debugFooterHeight),
         tostring(gap)
     ))
+
+    local debugViewportHeight = nil
+    local scrollContainerForDebug = state.scrollContainer
+    if scrollContainerForDebug and scrollContainerForDebug.GetHeight then
+        local ok, h = pcall(scrollContainerForDebug.GetHeight, scrollContainerForDebug)
+        if ok and type(h) == "number" then
+            debugViewportHeight = h
+        end
+    end
+
+    local debugScrollRange = state.scrollMaxOffset
+
     debugLog(string.format(
         "Scroll viewport=%s content=%s range=%s",
-        tostring(viewportHeight),
+        tostring(debugViewportHeight),
         tostring(totalContentHeight),
-        tostring(maxOffset)
+        tostring(debugScrollRange)
     ))
 
     local desiredOffset = math.max(0, previousDesired or 0)


### PR DESCRIPTION
## Summary
- add debug logging for scroll viewport height, content height, and scroll range alongside existing height debug output

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b28a0fcd8832aa18482e33acc4f9d)