### PR TITLE
Fix favorites refresh when achievements hidden

### DIFF
--- a/Model/Achievement/Nvk3UT_FavoritesIntegration.lua
+++ b/Model/Achievement/Nvk3UT_FavoritesIntegration.lua
@@ -232,16 +232,6 @@ local function _shouldRefreshFavorites()
         return false
     end
 
-    local control = achievements.control
-    if control and control.IsHidden and control:IsHidden() then
-        return false
-    end
-
-    local sceneManager = SCENE_MANAGER
-    if sceneManager and sceneManager.IsShowing and not sceneManager:IsShowing("achievements") then
-        return false
-    end
-
     local tree = achievements.categoryTree
     if not (tree and tree.GetSelectedData) then
         return false


### PR DESCRIPTION
## Summary
- relax the favorites refresh gate so changes update even when the achievements scene is hidden
- keep existing favorites category checks while allowing live refresh to run after favorites mutations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b58d1a1a0832aa7538a25e4a41db5)