### PR TITLE
Fix Quest Tracker “Show On Map” context action to match Ravalox behaviour

### DIFF
--- a/Nvk3UT_QuestTracker.lua
+++ b/Nvk3UT_QuestTracker.lua
@@ -1273,24 +1273,7 @@ end
 
 local function CanQuestBeShownOnMap(journalIndex)
     local normalized = NormalizeJournalIndex(journalIndex)
-    if not normalized then
-        return false
-    end
-
-    -- Mirror the base quest journal gating so availability matches the vanilla UI.
-    local managerOk, managerResult = QuestManagerCall("CanShowOnMap", normalized)
-    if managerOk then
-        return IsTruthy(managerResult)
-    end
-
-    if type(DoesJournalQuestHaveWorldMapLocation) == "function" then
-        local ok, hasLocation = SafeCall(DoesJournalQuestHaveWorldMapLocation, normalized)
-        if ok then
-            return IsTruthy(hasLocation)
-        end
-    end
-
-    return false
+    return normalized ~= nil
 end
 
 local function ShowQuestOnMap(journalIndex)
@@ -1301,6 +1284,14 @@ local function ShowQuestOnMap(journalIndex)
 
     if type(ZO_WorldMap_ShowQuestOnMap) ~= "function" then
         return
+    end
+
+    if IsDebugLoggingEnabled() then
+        DebugLog(string.format(
+            "SHOW_QUEST_ON_MAP questIndex=%s normalized=%s",
+            tostring(journalIndex),
+            tostring(normalized)
+        ))
     end
 
     -- Mirror the reference tracker by delegating straight to the base-game
@@ -1362,9 +1353,7 @@ local function BuildQuestContextMenuEntries(journalIndex)
             return CanQuestBeShownOnMap(journalIndex)
         end,
         callback = function()
-            if CanQuestBeShownOnMap(journalIndex) then
-                ShowQuestOnMap(journalIndex)
-            end
+            ShowQuestOnMap(journalIndex)
         end,
     }
 


### PR DESCRIPTION
Fixes #0

## Summary
- relax the show-on-map gate to accept valid journal indices and rely on the base helper
- log the quest index when debug logging is enabled and call the world map helper directly
- trigger the quest map action from the context menu without redundant gating

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5ccfb2d4832a835aa292a3107e11)