### PR TITLE
Nvk3UT v7 – Add safe 2-step rebuild after category/entry toggle

### DIFF
--- a/Nvk3UT_AchievementTracker.lua
+++ b/Nvk3UT_AchievementTracker.lua
@@ -78,6 +78,13 @@ local VERTICAL_PADDING = 3
 
 local CATEGORY_KEY = "achievements"
 
+local function ScheduleToggleFollowup(reason)
+    local rebuild = (Nvk3UT and Nvk3UT.Rebuild) or _G.Nvk3UT_Rebuild
+    if rebuild and type(rebuild.ScheduleToggleFollowup) == "function" then
+        rebuild.ScheduleToggleFollowup(reason)
+    end
+end
+
 local CATEGORY_MIN_HEIGHT = 26
 local ACHIEVEMENT_MIN_HEIGHT = 24
 local OBJECTIVE_MIN_HEIGHT = 20
@@ -1316,6 +1323,7 @@ local function AcquireCategoryControl()
                 source = "AchievementTracker:OnCategoryClick",
             })
             AchievementTracker.Refresh()
+            ScheduleToggleFollowup("achievementCategoryToggle")
         end)
         control:SetHandler("OnMouseEnter", function(ctrl)
             if ctrl.label then
@@ -1388,6 +1396,7 @@ local function AcquireAchievementControl()
                 local expanded = not IsEntryExpanded(achievementId)
                 SetEntryExpanded(achievementId, expanded, "AchievementTracker:ToggleAchievementObjectives")
                 AchievementTracker.Refresh()
+                ScheduleToggleFollowup("achievementEntryToggle")
             elseif button == RIGHT_MOUSE_BUTTON then
                 if not ctrl.data or not ctrl.data.achievementId then
                     return

--- a/Nvk3UT_QuestTracker.lua
+++ b/Nvk3UT_QuestTracker.lua
@@ -65,6 +65,13 @@ local REFRESH_DEBOUNCE_MS = 80
 
 local COLOR_ROW_HOVER = { 1, 1, 0.6, 1 }
 
+local function ScheduleToggleFollowup(reason)
+    local rebuild = (Nvk3UT and Nvk3UT.Rebuild) or _G.Nvk3UT_Rebuild
+    if rebuild and type(rebuild.ScheduleToggleFollowup) == "function" then
+        rebuild.ScheduleToggleFollowup(reason)
+    end
+end
+
 local RequestRefresh -- forward declaration for functions that trigger refreshes
 local SetCategoryExpanded -- forward declaration for expansion helpers used before assignment
 local SetQuestExpanded
@@ -2975,6 +2982,7 @@ local function ToggleQuestExpansion(journalIndex, context)
     local changed = SetQuestExpanded(journalIndex, not expanded, toggleContext)
     if changed then
         QuestTracker.Refresh()
+        ScheduleToggleFollowup("questEntryToggle")
     end
 
     return changed
@@ -3025,6 +3033,7 @@ local function AcquireCategoryControl()
             })
             if changed then
                 QuestTracker.Refresh()
+                ScheduleToggleFollowup("questCategoryToggle")
             end
         end)
         control:SetHandler("OnMouseEnter", function(ctrl)

--- a/Tracker/Endeavor/Nvk3UT_EndeavorTracker.lua
+++ b/Tracker/Endeavor/Nvk3UT_EndeavorTracker.lua
@@ -118,6 +118,13 @@ local CATEGORY_COLOR_ROLE_EXPANDED = "activeTitle"
 local CATEGORY_COLOR_ROLE_COLLAPSED = "categoryTitle"
 local ENTRY_COLOR_ROLE_DEFAULT = "entryTitle"
 
+local function scheduleToggleFollowup(reason)
+    local rebuild = (Nvk3UT and Nvk3UT.Rebuild) or _G.Nvk3UT_Rebuild
+    if rebuild and type(rebuild.ScheduleToggleFollowup) == "function" then
+        rebuild.ScheduleToggleFollowup(reason)
+    end
+end
+
 local ENDEAVOR_TRACKER_COLOR_KIND = "endeavorTracker"
 
 local function coerceHeight(value)
@@ -400,6 +407,7 @@ local function toggleRootExpanded()
     local okSet = CallIfFunction(stateModule.SetExpanded, stateModule, not expanded)
     if okSet then
         queueTrackerDirty()
+        scheduleToggleFollowup("endeavorRootToggle")
     end
 end
 
@@ -422,6 +430,7 @@ local function toggleCategoryExpanded(key)
     local okSet = CallIfFunction(stateModule.SetCategoryExpanded, stateModule, key, not expanded)
     if okSet then
         queueTrackerDirty()
+        scheduleToggleFollowup("endeavorCategoryToggle")
     end
 end
 

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerController.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerController.lua
@@ -23,6 +23,13 @@ local state = {
     entryExpanded = true,
 }
 
+local function scheduleToggleFollowup(reason)
+    local rebuild = (Nvk3UT and Nvk3UT.Rebuild) or _G.Nvk3UT_Rebuild
+    if rebuild and type(rebuild.ScheduleToggleFollowup) == "function" then
+        rebuild.ScheduleToggleFollowup(reason)
+    end
+end
+
 local attachments = {
     model = nil,
     tracker = nil,
@@ -831,6 +838,7 @@ function Controller:ToggleHeaderExpanded()
 
     if changed then
         self:MarkDirty("ToggleHeaderExpanded")
+        scheduleToggleFollowup("goldenCategoryToggle")
     end
 end
 
@@ -841,6 +849,7 @@ end
 function Controller:ToggleEntryExpanded()
     toggleEntryExpanded()
     self:MarkDirty("ToggleEntryExpanded")
+    scheduleToggleFollowup("goldenEntryToggle")
 end
 
 return Controller


### PR DESCRIPTION
## Summary
- add a centralized `Rebuild.ScheduleToggleFollowup` helper that queues a 1ms delayed rebuild using the existing runtime pipeline and avoids re-scheduling loops
- invoke the helper from quest, achievement, endeavor, and golden tracker toggle interactions so large expand/collapse actions always get a follow-up layout pass

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dadea1888832a99153dac4ce7344a)