### PR TITLE
Nvk3UT v7 – Golden objective handling options

### DIFF
--- a/Core/Nvk3UT_StateInit.lua
+++ b/Core/Nvk3UT_StateInit.lua
@@ -274,6 +274,7 @@ local function CreateTrackerDefaults(fontDefaultsCopier)
         Enabled = true,
         ShowCountsInHeaders = true,
         CompletedHandling = "hide",
+        CompletedHandlingObjectives = "hide",
         Colors = {
             CategoryTitle = CopyColor(COLOR_CATEGORY),
             EntryName = CopyColor(COLOR_ENTRY),


### PR DESCRIPTION
Fixes #7

## Summary
- store the Golden objective handling dropdown value in the tracker defaults/saved variables with "Ausblenden" as the default for fresh profiles
- teach the Golden tracker controller to read that saved option, filter completed objectives when "Ausblenden" is selected, and log the resulting counts for debugging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691db67880c4832aa754322f4dda6061)