### PR TITLE
Nvk3UT v7 – Golden: implement general completed handling (hide or recolor campaign on capstone)

### DIFF
--- a/Nvk3UT_LAM.lua
+++ b/Nvk3UT_LAM.lua
@@ -2567,12 +2567,14 @@ local function registerPanel(displayTitle)
                 choices = {
                     GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_HIDE),
                     GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_RECOLOR),
-                    GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_SHOW_OPEN_OBJECTIVES),
                 },
-                choicesValues = { "hide", "recolor", "openObjectives" },
+                choicesValues = { "hide", "recolor" },
                 getFunc = function()
                     local config = getGoldenConfig()
-                    local value = config.CompletedHandlingGeneral
+                    local value = config.generalCompletedHandling
+                    if value == nil then
+                        value = config.CompletedHandlingGeneral
+                    end
                     if value == nil then
                         local legacy = config.CompletedHandling
                         if legacy == "recolor" then
@@ -2582,19 +2584,13 @@ local function registerPanel(displayTitle)
                     end
                     if value == "recolor" then
                         return "recolor"
-                    elseif value == "openObjectives" then
-                        return "openObjectives"
                     end
                     return "hide"
                 end,
                 setFunc = function(value)
                     local config = getGoldenConfig()
-                    local resolved = "hide"
-                    if value == "recolor" then
-                        resolved = "recolor"
-                    elseif value == "openObjectives" then
-                        resolved = "openObjectives"
-                    end
+                    local resolved = value == "recolor" and "recolor" or "hide"
+                    config.generalCompletedHandling = resolved
                     config.CompletedHandlingGeneral = resolved
                     if config.CompletedHandling ~= nil then
                         if resolved == "recolor" then
@@ -2636,7 +2632,7 @@ local function registerPanel(displayTitle)
                         return "hide"
                     end
 
-                    local general = config.CompletedHandlingGeneral
+                    local general = config.generalCompletedHandling or config.CompletedHandlingGeneral
                     if general == "recolor" or general == "hide" then
                         return general
                     end

--- a/Tracker/Golden/Nvk3UT_GoldenTracker.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTracker.lua
@@ -1032,6 +1032,21 @@ function GoldenTracker.Refresh(...)
     local summary = type(vm) == "table" and type(vm.summary) == "table" and vm.summary or {}
     local objectives = type(vm) == "table" and type(vm.objectives) == "table" and vm.objectives or {}
     local hasEntriesForTracker = type(vm) == "table" and vm.hasEntriesForTracker == true
+    local capstoneReached = vm and (vm.capstoneReached == true or summary.capstoneReached == true)
+    local generalMode = vm and (vm.generalCompletedMode or summary.generalCompletedMode)
+    local hideCategoryWhenCompleted = vm and (vm.hideCategoryWhenCompleted == true or summary.hideCategoryWhenCompleted == true)
+    local hideObjectivesWhenCompleted = vm and (vm.hideObjectivesWhenCompleted == true or summary.hideObjectivesWhenCompleted == true)
+
+    if hideCategoryWhenCompleted then
+        hasEntriesForTracker = false
+        if vm then
+            vm.hasEntriesForTracker = false
+            if type(vm.status) == "table" then
+                vm.status.hasEntriesForTracker = false
+                vm.status.hasEntries = false
+            end
+        end
+    end
 
     safeDebug(
         "Refresh start: vmNil=%s hasEntriesForTracker=%s hasCampaign=%s objectives=%d",
@@ -1040,6 +1055,16 @@ function GoldenTracker.Refresh(...)
         tostring(summary.hasActiveCampaign),
         #objectives
     )
+
+    if capstoneReached ~= nil or generalMode ~= nil then
+        safeDebug(
+            "[GoldenTracker] generalMode=%s capstoneReached=%s hideCategory=%s hideObjectives=%s",
+            tostring(generalMode),
+            tostring(capstoneReached),
+            tostring(hideCategoryWhenCompleted),
+            tostring(hideObjectivesWhenCompleted)
+        )
+    end
 
     if vm == nil then
         tracker.height = 0
@@ -1105,6 +1130,9 @@ function GoldenTracker.Refresh(...)
         end
 
         if categoryExpanded and entryExpanded then
+            if hideObjectivesWhenCompleted then
+                objectives = {}
+            end
             for objectiveIndex = 1, #objectives do
                 local objectiveData = objectives[objectiveIndex]
                 if type(objectiveData) == "table" then

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
@@ -891,16 +891,24 @@ function Rows.CreateCampaignRow(parent, entryData)
             end
         end
         local entryComplete = isCapstoneComplete(entryData)
-        local entryRole = GOLDEN_COLOR_ROLES.EntryName
+        local generalMode = type(entryData) == "table" and entryData.generalCompletedMode
+        local useCompletedColor = entryComplete and generalMode == "recolor"
+        local entryRole = useCompletedColor and GOLDEN_COLOR_ROLES.Completed or GOLDEN_COLOR_ROLES.EntryName
         local colorR, colorG, colorB, colorA, colorSource, colorSourceReason = applyLabelColor(label, entryRole, palette)
         if colorR ~= nil and isGoldenColorDebugEnabled() then
             local stateTokens = {
                 entryExpanded and "active" or "inactive",
                 entryComplete and "capstoneComplete" or "capstoneOpen",
+                generalMode,
             }
-            local reason = "Campaign entry always uses entry title color"
-            if entryExpanded or entryComplete then
-                reason = string.format("%s (active/completed state ignored for color)", reason)
+            local reason
+            if useCompletedColor then
+                reason = "Capstone reached with general recolor; using completed color"
+            else
+                reason = "Campaign entry always uses entry title color"
+                if entryExpanded or entryComplete then
+                    reason = string.format("%s (active/completed state ignored for color)", reason)
+                end
             end
             if colorSourceReason and colorSourceReason ~= "" then
                 reason = string.format("%s (%s)", reason, colorSourceReason)


### PR DESCRIPTION
## Summary
- store the Golden general completed-handling dropdown as a hide/recolor toggle in saved variables
- add general handling and capstone flags to the Golden tracker view model and controller
- hide or recolor the Golden campaign and objectives in the tracker UI when the capstone is reached

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ba92ca74832a9442e1429bf4d317)