### PR TITLE
Nvk3UT v7 – Golden: add “Offene weiter anzeigen” general completed handling mode

### DIFF
--- a/Model/Golden/Nvk3UT_GoldenState.lua
+++ b/Model/Golden/Nvk3UT_GoldenState.lua
@@ -17,6 +17,7 @@ local unpack = _G.unpack or (table and table.unpack)
 local VALID_COMPLETED_HANDLING = {
     hide = true,
     recolor = true,
+    showOpen = true,
 }
 
 local DEFAULT_BEHAVIOR = {

--- a/Nvk3UT_LAM.lua
+++ b/Nvk3UT_LAM.lua
@@ -2567,8 +2567,9 @@ local function registerPanel(displayTitle)
                 choices = {
                     GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_HIDE),
                     GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_RECOLOR),
+                    GetString(SI_NVK3UT_LAM_GOLDEN_COMPLETED_SHOW_OPEN_OBJECTIVES),
                 },
-                choicesValues = { "hide", "recolor" },
+                choicesValues = { "hide", "recolor", "showOpen" },
                 getFunc = function()
                     local config = getGoldenConfig()
                     local value = config.generalCompletedHandling
@@ -2582,6 +2583,9 @@ local function registerPanel(displayTitle)
                         end
                         return "hide"
                     end
+                    if value == "showOpen" then
+                        return "showOpen"
+                    end
                     if value == "recolor" then
                         return "recolor"
                     end
@@ -2589,25 +2593,22 @@ local function registerPanel(displayTitle)
                 end,
                 setFunc = function(value)
                     local config = getGoldenConfig()
-                    local resolved = value == "recolor" and "recolor" or "hide"
+                    local resolved = "hide"
+                    if value == "recolor" then
+                        resolved = "recolor"
+                    elseif value == "showOpen" then
+                        resolved = "showOpen"
+                    end
                     config.generalCompletedHandling = resolved
                     config.CompletedHandlingGeneral = resolved
                     if config.CompletedHandling ~= nil then
-                        if resolved == "recolor" then
-                            config.CompletedHandling = "recolor"
-                        else
-                            config.CompletedHandling = "hide"
-                        end
+                        config.CompletedHandling = resolved == "recolor" and "recolor" or "hide"
                     end
                     refreshGoldenModel()
                     if LamQueueFullRebuild("goldenCompletedHandlingGeneral") then
                         return
                     end
-                    if resolved == "hide" then
-                        markGoldenDirty("filter")
-                    else
-                        markGoldenDirty("appearance")
-                    end
+                    markGoldenDirty(resolved == "hide" and "filter" or "appearance")
                     queueGoldenDirty()
                 end,
                 default = "hide",

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
@@ -810,8 +810,14 @@ function Rows.CreateCategoryRow(parent, categoryData)
         local text = GOLDEN_HEADER_TITLE
         local showCounter = shouldShowGoldenHeaderCounter()
         local remaining = nil
+        local generalMode = type(categoryData) == "table" and categoryData.generalCompletedMode
+        local capstoneReached = categoryData and categoryData.capstoneReached == true
         if type(categoryData) == "table" then
-            remaining = tonumber(categoryData.remainingObjectivesToNextReward) or 0
+            if showCounter and capstoneReached and generalMode == "showOpen" then
+                remaining = tonumber(categoryData.remainingAllObjectives) or 0
+            else
+                remaining = tonumber(categoryData.remainingObjectivesToNextReward) or 0
+            end
         end
 
         if showCounter and remaining ~= nil then
@@ -934,6 +940,17 @@ function Rows.CreateCampaignRow(parent, entryData)
             end
             if total == nil then
                 total = tonumber(entryData.max) or tonumber(entryData.maxDisplay)
+            end
+
+            local overallCompleted = tonumber(entryData.totalCompletedOverall)
+            local capstoneGoal = tonumber(entryData.capstoneGoal or entryData.maxRewardTier or entryData.countTotal)
+            if entryComplete and generalMode == "showOpen" then
+                if overallCompleted ~= nil then
+                    completed = overallCompleted
+                end
+                if capstoneGoal ~= nil then
+                    total = capstoneGoal
+                end
             end
 
             if completed ~= nil and total ~= nil then


### PR DESCRIPTION
## Summary
- add the “Offene weiter anzeigen” option to the Golden general completed handling dropdown and saved configuration
- surface overall objective totals and new mode flags in the Golden view model and refresh logic to keep the category and campaign visible after capstone with open objectives
- adjust Golden rows to display the new header count and campaign progress suffix while keeping completed objectives hidden in the new mode

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921bdd26450832a829dcfe1ab98066b)