### PR TITLE
Add pinned Golden objective marker and refresh tracker on pin change

### DIFF
--- a/Core/Nvk3UT_Core.lua
+++ b/Core/Nvk3UT_Core.lua
@@ -2,7 +2,7 @@
 -- Central addon root. Owns global table, SafeCall, module registry, SavedVariables bootstrap, lifecycle entry points.
 
 local ADDON_NAME    = ADDON_NAME    or "Nvk3UT"
-local ADDON_VERSION = ADDON_VERSION or "0.11.15" -- TODO: keep in sync with manifest when version updates
+local ADDON_VERSION = ADDON_VERSION or "0.11.16" -- TODO: keep in sync with manifest when version updates
 local unpack = unpack or table.unpack
 
 Nvk3UT = Nvk3UT or {}

--- a/Model/Golden/Nvk3UT_GoldenList.lua
+++ b/Model/Golden/Nvk3UT_GoldenList.lua
@@ -375,6 +375,7 @@ local function normalizeEntry(rawEntry, categoryKey, fallbackRemaining, entryInd
     normalized.campaignId = rawEntry.campaignId
     normalized.campaignKey = rawEntry.campaignKey
     normalized.campaignIndex = rawEntry.campaignIndex
+    normalized.activityIndex = rawEntry.activityIndex or entryIndex
     normalized.rewardId = rawEntry.rewardId
     normalized.rewardQuantity = rawEntry.rewardQuantity
     normalized.isRewardClaimed = rawEntry.isRewardClaimed == true

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Favorites category + context menu; 'Kürzlich' as its own category with same icon; Status + LAM.
 ## Author: Nvk3
-## Version: 0.11.15
-## AddOnVersion: 1115
+## Version: 0.11.16
+## AddOnVersion: 1116
 ## APIVersion: 101041 101042 101043
 ## DependsOn: LibAddonMenu-2.0
 ## OptionalDependsOn: LibCustomMenu-2.0

--- a/Tracker/Golden/Nvk3UT_GoldenTracker.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTracker.lua
@@ -760,18 +760,21 @@ local GOLDEN_TEMP_EVENT_HANDLES = {
     updated = GOLDEN_TEMP_EVENT_NAMESPACE .. ".PursuitsUpdated",
     progress = GOLDEN_TEMP_EVENT_NAMESPACE .. ".ProgressUpdated",
     status = GOLDEN_TEMP_EVENT_NAMESPACE .. ".StatusUpdated",
+    tracking = GOLDEN_TEMP_EVENT_NAMESPACE .. ".TrackingUpdated",
 }
 
 local GOLDEN_TEMP_EVENT_REASONS = {
     updated = "EVENT_GOLDEN_PURSUITS_UPDATED",
     progress = "EVENT_GOLDEN_PURSUITS_PROGRESS_UPDATED",
     status = "EVENT_GOLDEN_PURSUITS_STATUS_UPDATED",
+    tracking = "EVENT_PROMOTIONAL_EVENTS_ACTIVITY_TRACKING_UPDATED",
 }
 
 local GOLDEN_TEMP_EVENT_IDS = {
     updated = rawget(_G, "EVENT_GOLDEN_PURSUITS_UPDATED"),
     progress = rawget(_G, "EVENT_GOLDEN_PURSUITS_PROGRESS_UPDATED"),
     status = rawget(_G, "EVENT_GOLDEN_PURSUITS_STATUS_UPDATED"),
+    tracking = rawget(_G, "EVENT_PROMOTIONAL_EVENTS_ACTIVITY_TRACKING_UPDATED"),
 }
 
 local goldenTempEventsState = {
@@ -930,6 +933,12 @@ local function onGoldenPursuitsStatusUpdated(...)
     scheduleGoldenProgressFallback(reason)
 end
 
+local function onGoldenPursuitsTrackingUpdated(...)
+    local reason = GOLDEN_TEMP_EVENT_REASONS.tracking
+    safeDebug("[GoldenTracker.TempEvents] %s", reason)
+    queueGoldenTempEventRefreshSafe(reason)
+end
+
 local function registerGoldenTempEvents()
     if goldenTempEventsState.registered then
         return
@@ -978,6 +987,15 @@ local function registerGoldenTempEvents()
         registeredCount = registeredCount + 1
     end
 
+    if GOLDEN_TEMP_EVENT_IDS.tracking ~= nil then
+        eventManager:RegisterForEvent(
+            GOLDEN_TEMP_EVENT_HANDLES.tracking,
+            GOLDEN_TEMP_EVENT_IDS.tracking,
+            onGoldenPursuitsTrackingUpdated
+        )
+        registeredCount = registeredCount + 1
+    end
+
     if registeredCount > 0 then
         goldenTempEventsState.registered = true
         safeDebug("[GoldenTracker.TempEvents] register (%d handlers)", registeredCount)
@@ -1006,6 +1024,7 @@ local function unregisterGoldenTempEvents()
     unregisterMethod(eventManager, GOLDEN_TEMP_EVENT_HANDLES.updated)
     unregisterMethod(eventManager, GOLDEN_TEMP_EVENT_HANDLES.progress)
     unregisterMethod(eventManager, GOLDEN_TEMP_EVENT_HANDLES.status)
+    unregisterMethod(eventManager, GOLDEN_TEMP_EVENT_HANDLES.tracking)
 
     goldenTempEventsState.registered = false
     safeDebug("[GoldenTracker.TempEvents] unregister")

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
@@ -45,6 +45,7 @@ local DEFAULTS = {
     ENTRY_FONT = "$(BOLD_FONT)|16|soft-shadow-thick",
     OBJECTIVE_FONT = "$(BOLD_FONT)|14|soft-shadow-thick",
     OBJECTIVE_INDENT_X = 60,
+    OBJECTIVE_PIN_MARKER_OFFSET_X = 10,
 }
 
 local GOLDEN_HEADER_TITLE = "GOLDENE VORHABEN"
@@ -995,11 +996,36 @@ function Rows.CreateObjectiveRow(parent, objectiveData)
 
     local palette = getGoldenTrackerColors()
     local label = createLabel(control, "Objective")
+    local pinLabel = control.__pinnedLabel
     if label then
         label:ClearAnchors()
         if label.SetAnchor then
             label:SetAnchor(TOPLEFT, control, TOPLEFT, DEFAULTS.OBJECTIVE_INDENT_X, 0)
             label:SetAnchor(BOTTOMRIGHT, control, BOTTOMRIGHT, 0, 0)
+        end
+
+        if pinLabel == nil then
+            pinLabel = createLabel(control, "ObjectivePin")
+            control.__pinnedLabel = pinLabel
+            if pinLabel then
+                pinLabel:ClearAnchors()
+                if pinLabel.SetAnchor then
+                    pinLabel:SetAnchor(
+                        LEFT,
+                        control,
+                        LEFT,
+                        DEFAULTS.OBJECTIVE_INDENT_X - DEFAULTS.OBJECTIVE_PIN_MARKER_OFFSET_X,
+                        0
+                    )
+                end
+                applyLabelDefaults(pinLabel, getGoldenObjectiveFont())
+                if pinLabel.SetText then
+                    pinLabel:SetText("*")
+                end
+                if pinLabel.SetHidden then
+                    pinLabel:SetHidden(true)
+                end
+            end
         end
         local role = isObjectiveCompleted(objectiveData) and GOLDEN_COLOR_ROLES.Completed or GOLDEN_COLOR_ROLES.Objective
         applyLabelDefaults(label, getGoldenObjectiveFont())
@@ -1059,6 +1085,11 @@ function Rows.CreateObjectiveRow(parent, objectiveData)
         if label.SetText then
             label:SetText(text)
         end
+    end
+
+    local isPinned = type(objectiveData) == "table" and objectiveData.isPinned == true
+    if pinLabel and pinLabel.SetHidden then
+        pinLabel:SetHidden(not isPinned)
     end
 
     return control


### PR DESCRIPTION
## Summary
- carry through Golden activity indices and resolve pinned objective from the tracked ESO activity
- display a pinned marker in the Golden tracker rows without shifting existing text
- refresh the Golden tracker when the tracked activity changes and bump addon version

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921daa01c20832a95a3834ea601f7e5)