### PR TITLE
Order Golden objectives so pinned activity is listed first

### DIFF
--- a/Core/Nvk3UT_Core.lua
+++ b/Core/Nvk3UT_Core.lua
@@ -2,7 +2,7 @@
 -- Central addon root. Owns global table, SafeCall, module registry, SavedVariables bootstrap, lifecycle entry points.
 
 local ADDON_NAME    = ADDON_NAME    or "Nvk3UT"
-local ADDON_VERSION = ADDON_VERSION or "0.11.16" -- TODO: keep in sync with manifest when version updates
+local ADDON_VERSION = ADDON_VERSION or "0.11.17" -- TODO: keep in sync with manifest when version updates
 local unpack = unpack or table.unpack
 
 Nvk3UT = Nvk3UT or {}

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Favorites category + context menu; 'Kürzlich' as its own category with same icon; Status + LAM.
 ## Author: Nvk3
-## Version: 0.11.16
-## AddOnVersion: 1116
+## Version: 0.11.17
+## AddOnVersion: 1117
 ## APIVersion: 101041 101042 101043
 ## DependsOn: LibAddonMenu-2.0
 ## OptionalDependsOn: LibCustomMenu-2.0

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerController.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerController.lua
@@ -1010,7 +1010,37 @@ function Controller:BuildViewModel(options)
         end
     end
 
-    viewModel.objectives = trackerObjectives
+    local pinnedObjectives = {}
+    local normalObjectives = {}
+
+    for index = 1, #trackerObjectives do
+        local objectiveData = trackerObjectives[index]
+        if objectiveData and objectiveData.isPinned == true then
+            pinnedObjectives[#pinnedObjectives + 1] = objectiveData
+        else
+            normalObjectives[#normalObjectives + 1] = objectiveData
+        end
+    end
+
+    local orderedObjectives = {}
+    for index = 1, #pinnedObjectives do
+        orderedObjectives[#orderedObjectives + 1] = pinnedObjectives[index]
+    end
+    for index = 1, #normalObjectives do
+        orderedObjectives[#orderedObjectives + 1] = normalObjectives[index]
+    end
+
+    if isDebugEnabled() then
+        local firstPinnedIndex = #pinnedObjectives > 0 and 1 or "n/a"
+        safeDebug(
+            "[GoldenController] pinned ordering: pinned=%d normal=%d firstPinnedIndex=%s",
+            #pinnedObjectives,
+            #normalObjectives,
+            tostring(firstPinnedIndex)
+        )
+    end
+
+    viewModel.objectives = orderedObjectives
 
     viewModel.generalCompletedMode = generalHandling
     viewModel.capstoneReached = capstoneReached
@@ -1040,7 +1070,7 @@ function Controller:BuildViewModel(options)
     state.viewModel = viewModel
     state.dirty = false
 
-    local trackerObjectiveCount = #trackerObjectives
+    local trackerObjectiveCount = #viewModel.objectives
 
     safeDebug(
         "BuildViewModel populated: avail=%s locked=%s hasEntries=%s hasEntriesForTracker=%s campaigns=%d activities=%d/%d objectives=%d",


### PR DESCRIPTION
## Summary
- partition the Golden tracker objectives to place pinned objectives at the top while preserving existing order
- add optional debug output describing pinned objective ordering
- bump addon version to 0.11.17/1117 to reflect the new behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dc64e9bc832a898d4ea66103ecb7)