### PR TITLE
GUI_001C: Add entry pooling to Golden tracker

### DIFF
--- a/Tracker/Golden/Nvk3UT_GoldenTracker.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTracker.lua
@@ -1066,6 +1066,10 @@ function GoldenTracker.Refresh(...)
         rowsModule.ReleaseAllCategoryRows()
     end
 
+    if rowsModule and type(rowsModule.ReleaseAllEntryRows) == "function" then
+        rowsModule.ReleaseAllEntryRows()
+    end
+
     ClearChildren(content)
 
     tracker.viewModel = type(viewModel) == "table" and viewModel or nil
@@ -1175,9 +1179,20 @@ function GoldenTracker.Refresh(...)
                     campaignPayload.isExpanded = entryExpanded
                 end
 
-                local campaignRow = safeCreateRow(rowsModule.CreateCampaignRow, content, campaignPayload)
+                local campaignRow = nil
+                if type(rowsModule.AcquireEntryRow) == "function" then
+                    campaignRow = rowsModule.AcquireEntryRow(content)
+                    if campaignRow and type(rowsModule.ApplyEntryRow) == "function" then
+                        rowsModule.ApplyEntryRow(campaignRow, campaignPayload)
+                    end
+                end
+
+                if campaignRow == nil then
+                    campaignRow = safeCreateRow(rowsModule.CreateCampaignRow, content, campaignPayload)
+                end
+
                 if campaignRow then
-                    table.insert(rows, campaignRow)
+                    table.insert(rows, campaignRow.control or campaignRow)
                 end
             end
         end

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
@@ -91,6 +91,14 @@ local function applyDimensions(row, parentWidth)
     end
 end
 
+local function resolveControl(row)
+    if type(row) == "table" and row.control then
+        return row.control, row
+    end
+
+    return row, row
+end
+
 function Layout.ApplyLayout(parentControl, rows)
     if not parentControl then
         safeDebug("ApplyLayout abort: parent missing")
@@ -114,7 +122,7 @@ function Layout.ApplyLayout(parentControl, rows)
 
     for index = 1, #rows do
         local row = rows[index]
-        local control = (type(row) == "table" and row.control) or row
+        local control, rowData = resolveControl(row)
         if control and (type(control) == "userdata" or type(control) == "table") then
             if type(control.ClearAnchors) == "function" then
                 control:ClearAnchors()
@@ -138,7 +146,7 @@ function Layout.ApplyLayout(parentControl, rows)
 
             applyDimensions(control, parentWidth)
 
-            local height = tonumber(control.__height) or tonumber(row and row.__height) or 0
+            local height = tonumber(control.__height) or tonumber(rowData and rowData.__height) or 0
             if type(control.GetHeight) == "function" then
                 local ok, measured = pcall(control.GetHeight, control)
                 if ok and type(measured) == "number" then


### PR DESCRIPTION
## Summary
- add a pooled entry row implementation for the Golden tracker mirroring the Endeavor pooling behavior
- reuse pooled entry rows during refresh/layout while preserving existing visuals and interactions
- maintain layout handling for pooled row metadata and release entry rows before rebuilds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fa281914832aaca8b3936f86a054)