### PR TITLE
GUI_002B_Migrate_CategoryEntry_Heights

### DIFF
--- a/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
@@ -138,6 +138,8 @@ local function resolveRowHeight(control, rowData)
             fallback = rowsModule.GetCategoryRowHeight()
         elseif kind == "entry" and type(rowsModule.GetEntryRowHeight) == "function" then
             fallback = rowsModule.GetEntryRowHeight()
+        elseif kind == "objective" and type(rowsModule.GetObjectiveRowHeight) == "function" then
+            fallback = rowsModule.GetObjectiveRowHeight()
         end
     end
 
@@ -196,10 +198,15 @@ function Layout.ApplyLayout(parentControl, rows)
 
     local rowsModule = getRowsModule()
     if rowsModule and type(rowsModule.GetCategoryRowHeight) == "function" and type(rowsModule.GetEntryRowHeight) == "function" then
+        local objectiveHeight
+        if type(rowsModule.GetObjectiveRowHeight) == "function" then
+            objectiveHeight = rowsModule.GetObjectiveRowHeight()
+        end
         safeDebug(
-            "ApplyLayout heights category=%s entry=%s",
+            "ApplyLayout heights category=%s entry=%s objective=%s",
             tostring(rowsModule.GetCategoryRowHeight()),
-            tostring(rowsModule.GetEntryRowHeight())
+            tostring(rowsModule.GetEntryRowHeight()),
+            tostring(objectiveHeight)
         )
     end
 

--- a/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerRows.lua
@@ -414,11 +414,18 @@ local ROW_HEIGHT_METRICS = {
         paddingTop = 0,
         paddingBottom = 0,
     },
+    [ROW_KINDS.objective] = {
+        fontKey = "Objective",
+        minHeight = DEFAULTS.OBJECTIVE_HEIGHT,
+        paddingTop = 0,
+        paddingBottom = 0,
+    },
 }
 
 local resolvedRowHeights = {
     [ROW_KINDS.category] = DEFAULTS.CATEGORY_HEIGHT,
     [ROW_KINDS.entry] = DEFAULTS.ENTRY_HEIGHT,
+    [ROW_KINDS.objective] = DEFAULTS.OBJECTIVE_HEIGHT,
 }
 
 local function measureFontHeight(font)
@@ -441,6 +448,8 @@ local function resolveMetricsFont(fontKey)
         return getGoldenCategoryFont()
     elseif fontKey == "Title" then
         return getGoldenTitleFont()
+    elseif fontKey == "Objective" then
+        return getGoldenObjectiveFont()
     end
 
     return nil
@@ -470,6 +479,10 @@ end
 
 local function getEntryRowHeight()
     return resolveRowHeight(ROW_KINDS.entry)
+end
+
+local function getObjectiveRowHeight()
+    return resolveRowHeight(ROW_KINDS.objective)
 end
 
 local function sanitizeColorNumber(value)
@@ -1538,9 +1551,10 @@ function Rows.CreateObjectiveRow(parent, objectiveData)
         return nil
     end
 
-    control.__height = DEFAULTS.OBJECTIVE_HEIGHT
+    local objectiveHeight = getObjectiveRowHeight()
+    control.__height = objectiveHeight
     if control.SetHeight then
-        control:SetHeight(DEFAULTS.OBJECTIVE_HEIGHT)
+        control:SetHeight(objectiveHeight)
     end
 
     local palette = getGoldenTrackerColors()
@@ -1650,6 +1664,10 @@ end
 
 function Rows.GetEntryRowHeight()
     return getEntryRowHeight()
+end
+
+function Rows.GetObjectiveRowHeight()
+    return getObjectiveRowHeight()
 end
 
 Nvk3UT.GoldenTrackerRows = Rows


### PR DESCRIPTION
## Summary
- add metric-based helpers for Golden tracker category and entry row heights and tag rows with consistent kinds
- update Golden layout to consume the new height helpers instead of hardcoded row heights

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921fbf7397c832a832e8ef504889c7f)