### PR TITLE
GUI_003B_Final_Wire_CleanLegacy

### DIFF
--- a/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
+++ b/Tracker/Golden/Nvk3UT_GoldenTrackerLayout.lua
@@ -40,38 +40,6 @@ local function getRowsModule()
     return nil
 end
 
-local function clearChildren(control)
-    if not control then
-        return
-    end
-
-    local getNumChildren = control.GetNumChildren
-    local getChild = control.GetChild
-    if type(getNumChildren) ~= "function" or type(getChild) ~= "function" then
-        return
-    end
-
-    local okCount, childCount = pcall(getNumChildren, control)
-    if not okCount or type(childCount) ~= "number" or childCount <= 0 then
-        return
-    end
-
-    for index = childCount - 1, 0, -1 do
-        local okChild, child = pcall(getChild, control, index)
-        if okChild and child then
-            if child.ClearAnchors then
-                child:ClearAnchors()
-            end
-            if child.SetParent then
-                child:SetParent(nil)
-            end
-            if child.SetHidden then
-                child:SetHidden(true)
-            end
-        end
-    end
-end
-
 local function getParentWidth(control)
     if not control or type(control.GetWidth) ~= "function" then
         return 0


### PR DESCRIPTION
## Summary
- wire the Golden tracker refresh pipeline to exclusively use pooled category, entry, and objective rows
- add pooled objective rows and centralized apply helpers to remove legacy control creation and dead row factories
- clean up layout/refresh scaffolding to rely on metric-driven heights while matching the Endeavor tracker flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692200128574832a808288a4af61a0e8)