### PR TITLE
Fix Endeavor category mouseover highlight

### DIFF
--- a/Tracker/Endeavor/Nvk3UT_EndeavorTrackerRows.lua
+++ b/Tracker/Endeavor/Nvk3UT_EndeavorTrackerRows.lua
@@ -1369,6 +1369,14 @@ local function createCategoryRow(parent)
         control:SetHandler("OnMouseUp", onMouseUp)
         row._mouseHandler = onMouseUp
 
+        control:SetHandler("OnMouseEnter", function(ctrl)
+            applyMouseoverHighlight(ctrl)
+        end)
+
+        control:SetHandler("OnMouseExit", function(ctrl)
+            restoreMouseoverHighlight(ctrl)
+        end)
+
     end
 
     safeDebug("[CategoryPool] create %s", controlName)


### PR DESCRIPTION
## Summary
- wire Endeavor category rows to use the shared mouseover highlight handlers
- keep hover color consistent with Golden and Achievement tracker categories

## Testing
- not run (not requested)

Fixes #1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e4edc200832a844b9edbf06952bc)