### PR TITLE
Fix: run immediate full rebuild when tracker becomes visible to remove quest–endeavor gap

### DIFF
--- a/Runtime/Nvk3UT_TrackerHost.lua
+++ b/Runtime/Nvk3UT_TrackerHost.lua
@@ -1426,6 +1426,14 @@ local function triggerDeferredFullRebuildOnVisible()
             runtime:QueueDirty("layout")
         end)
     end
+
+    local rebuild = (Nvk3UT and Nvk3UT.Rebuild) or _G.Nvk3UT_Rebuild
+    local rebuildAll = rebuild and (rebuild.All or rebuild.all)
+    if type(rebuildAll) == "function" and TrackerHost.IsVisible() then
+        safeCall(function()
+            rebuildAll("sceneVisible:needsFullRebuild")
+        end)
+    end
 end
 
 local function requestHostFullRebuild(context)


### PR DESCRIPTION
## Summary
- process queued full rebuild work immediately when the tracker host is visible, avoiding an extra frame delay
- trigger full rebuilds directly when deferred work is released on becoming visible to stack sections correctly on the first frame

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692310e13764832aa02b11b3c06ee5e9)