### PR TITLE
Fix duplicate LAST50 entry in completed categories

### DIFF
--- a/Model/Achievement/Nvk3UT_CompletedData.lua
+++ b/Model/Achievement/Nvk3UT_CompletedData.lua
@@ -331,8 +331,19 @@ function CompletedData.GetSubcategoryList()
 
     for index = 1, #monthKeys do
         local key = monthKeys[index]
-        push(names, keyToName[key])
-        push(ids, key)
+        if key ~= LAST50_KEY then
+            push(names, keyToName[key])
+            push(ids, key)
+            if Nvk3UT.debugEnabled then
+                Nvk3UT.Diagnostics:Debug("[CompletedData:GetSubcategoryList:MONTH] index=%d key=%s name=%s",
+                    index, tostring(key), tostring(keyToName[key])
+                )
+            end
+        else
+            if Nvk3UT.debugEnabled then
+                Nvk3UT.Diagnostics:Debug("[CompletedData] skipped duplicate LAST50_KEY in month list (index=%d)", index)
+            end
+        end
     end
 
     return names, ids


### PR DESCRIPTION
## Summary
- avoid re-adding the LAST50 subcategory when iterating completed month keys
- log skipped duplicates when debug mode is enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d936b09f4832a86e8638eedb619a9)