### PR TITLE
Fix Quest/Achievement tracker category header count toggles

### DIFF
--- a/Nvk3UT_AchievementTracker.lua
+++ b/Nvk3UT_AchievementTracker.lua
@@ -23,6 +23,18 @@ local FormatCategoryHeaderText =
         return text
     end
 
+local function ShouldShowAchievementCategoryCounts()
+    local addon = Nvk3UT
+    local sv = addon and addon.SV
+    local general = sv and sv.General
+
+    if general and general.showAchievementCategoryCounts ~= nil then
+        return general.showAchievementCategoryCounts ~= false
+    end
+
+    return true
+end
+
 local function FormatDisplayString(text)
     if text == nil then
         return ""
@@ -1677,7 +1689,11 @@ local function LayoutCategory()
 
     local control = AcquireCategoryControl()
     control.data = { categoryKey = CATEGORY_KEY }
-    control.label:SetText(FormatCategoryHeaderText(GetString(SI_NVK3UT_TRACKER_ACHIEVEMENT_CATEGORY_MAIN), total or 0, "achievement"))
+    control.label:SetText(FormatCategoryHeaderText(
+        GetString(SI_NVK3UT_TRACKER_ACHIEVEMENT_CATEGORY_MAIN),
+        total or 0,
+        ShouldShowAchievementCategoryCounts()
+    ))
 
     local expanded = IsCategoryExpanded()
     local colorRole = expanded and "activeTitle" or "categoryTitle"

--- a/Nvk3UT_QuestTracker.lua
+++ b/Nvk3UT_QuestTracker.lua
@@ -22,6 +22,18 @@ local FormatCategoryHeaderText =
         return text
     end
 
+local function ShouldShowQuestCategoryCounts()
+    local addon = Nvk3UT
+    local sv = addon and addon.SV
+    local general = sv and sv.General
+
+    if general and general.showQuestCategoryCounts ~= nil then
+        return general.showQuestCategoryCounts ~= false
+    end
+
+    return true
+end
+
 local CATEGORY_TOGGLE_TEXTURES = {
     expanded = {
         up = "EsoUI/Art/Buttons/tree_open_up.dds",
@@ -3397,7 +3409,7 @@ local function LayoutCategory(category)
         state.categoryControls[normalizedKey] = control
     end
     local count = #category.quests
-    control.label:SetText(FormatCategoryHeaderText(category.name or "", count, "quest"))
+    control.label:SetText(FormatCategoryHeaderText(category.name or "", count, ShouldShowQuestCategoryCounts()))
     local expanded = IsCategoryExpanded(category.key)
     if IsDebugLoggingEnabled() then
         DebugLog(string.format(


### PR DESCRIPTION
## Summary
- add helpers to derive quest and achievement category count visibility from saved variables
- update category header formatting to use the helpers so LAM toggles apply immediately

Fixes #7

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9691a3dc832ab612ae38a845d161)