### PR TITLE
Move achievement tooltip LAM option to Journal section and remove unused tracker tooltip toggle

### DIFF
--- a/Nvk3UT_LAM.lua
+++ b/Nvk3UT_LAM.lua
@@ -1314,6 +1314,22 @@ local function registerPanel(displayTitle)
                 }
             end
 
+            controls[#controls + 1] = {
+                type = "checkbox",
+                name = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_ACHIEVEMENT_TOOLTIPS),
+                tooltip = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_ACHIEVEMENT_TOOLTIPS_DESC),
+                getFunc = function()
+                    local general = getGeneral()
+                    return general.features.tooltips ~= false
+                end,
+                setFunc = function(value)
+                    local general = getGeneral()
+                    general.features.tooltips = value
+                    updateTooltips(value)
+                end,
+                default = true,
+            }
+
             return controls
         end)(),
     }
@@ -2354,38 +2370,6 @@ local function registerPanel(displayTitle)
                     local general = getGeneral()
                     general.showAchievementCategoryCounts = value ~= false
                     refreshAchievementTracker()
-                end,
-                default = true,
-            }
-
-            controls[#controls + 1] = {
-                type = "checkbox",
-                name = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_TRACKER_TOOLTIPS),
-                tooltip = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_TRACKER_TOOLTIPS_DESC),
-                getFunc = function()
-                    local settings = getAchievementSettings()
-                    return settings.tooltips ~= false
-                end,
-                setFunc = function(value)
-                    local settings = getAchievementSettings()
-                    settings.tooltips = value
-                    applyAchievementSettings()
-                end,
-                default = true,
-            }
-
-            controls[#controls + 1] = {
-                type = "checkbox",
-                name = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_ACHIEVEMENT_TOOLTIPS),
-                tooltip = GetString(SI_NVK3UT_LAM_ACHIEVEMENT_ACHIEVEMENT_TOOLTIPS_DESC),
-                getFunc = function()
-                    local general = getGeneral()
-                    return general.features.tooltips ~= false
-                end,
-                setFunc = function(value)
-                    local general = getGeneral()
-                    general.features.tooltips = value
-                    updateTooltips(value)
                 end,
                 default = true,
             }


### PR DESCRIPTION
## Summary
- remove the unused tracker tooltip toggle from the Achievement Tracker LAM section
- relocate the existing achievement tooltip toggle into the Journal Extensions functions block while preserving its behavior

## Testing
- Not run (not requested)

Fixes #7

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9906ba74832ab29f61e67f487cab)