### PR TITLE
Bump Nvk3UT addon version to v0.13.14

### DIFF
--- a/Core/Nvk3UT_Core.lua
+++ b/Core/Nvk3UT_Core.lua
@@ -1,13 +1,15 @@
 -- Core/Nvk3UT_Core.lua
 -- Central addon root. Owns global table, SafeCall, module registry, SavedVariables bootstrap, lifecycle entry points.
 
-local ADDON_NAME    = ADDON_NAME    or "Nvk3UT"
-local ADDON_VERSION = "0.13.1"
+local ADDON_NAME        = ADDON_NAME        or "Nvk3UT"
+local ADDON_VERSION     = "0.13.14"
+local ADDON_VERSION_INT = 1314
 Nvk3UT = Nvk3UT or {}
 local Addon = Nvk3UT
 
 Addon.addonName    = ADDON_NAME
 Addon.addonVersion = ADDON_VERSION
+Addon.addonVersionInt = Addon.addonVersionInt or ADDON_VERSION_INT
 Addon.versionString = Addon.versionString or Addon.addonVersion
 Addon.SV           = Addon.SV or nil
 Addon.sv           = Addon.sv or Addon.SV -- legacy alias expected by existing modules

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Combines Quest, Endeavor, Achievement, Golden Pursuit and Journal enhancements into one customizable tracking window with category control, filtering and full LAM integration.
 ## Author: Nvk3
-## Version: 0.13.1
-## AddOnVersion: 1301
+## Version: 0.13.14
+## AddOnVersion: 1314
 ## APIVersion: 101048
 ## DependsOn: LibAddonMenu-2.0>=41 LibCustomMenu>=730
 ## OptionalDependsOn:


### PR DESCRIPTION
## Summary
- update manifest version to 0.13.14 with corresponding AddOnVersion integer
- sync core addon version constants (string and integer) for the new release

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de8a8844c832a938da0b821daf9fb)