### PR TITLE
Bump addon version to 0.14.7 (1407)

### DIFF
--- a/Core/Nvk3UT_Core.lua
+++ b/Core/Nvk3UT_Core.lua
@@ -2,8 +2,8 @@
 -- Central addon root. Owns global table, SafeCall, module registry, SavedVariables bootstrap, lifecycle entry points.
 
 local ADDON_NAME        = ADDON_NAME        or "Nvk3UT"
-local ADDON_VERSION     = "0.14.6"
-local ADDON_VERSION_INT = 1406
+local ADDON_VERSION     = "0.14.7"
+local ADDON_VERSION_INT = 1407
 Nvk3UT = Nvk3UT or {}
 local Addon = Nvk3UT
 

--- a/Nvk3UT.txt
+++ b/Nvk3UT.txt
@@ -1,8 +1,8 @@
 ## Title: Nvk3's Ultimate Tracker
 ## Description: Combines Quest, Endeavor, Achievement, Golden Pursuit and Journal enhancements into one customizable tracking window with category control, filtering and full LAM integration.
 ## Author: Nvk3
-## Version: 0.14.6
-## AddOnVersion: 1406
+## Version: 0.14.7
+## AddOnVersion: 1407
 ## APIVersion: 101048
 ## DependsOn: LibAddonMenu-2.0>=41 LibCustomMenu>=730
 ## OptionalDependsOn:


### PR DESCRIPTION
## Summary
- update manifest version fields to 0.14.7 / 1407
- align core string and integer version constants with the new release number

## Testing
- not run (not requested)

Fixes #0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ccf89fe4832ab5fa8f9760a1af99)