### PR TITLE
Stabilize multiline row height for Quest and Achievement trackers

### DIFF
--- a/Tracker/Achievement/Nvk3UT_AchievementTrackerRows.lua
+++ b/Tracker/Achievement/Nvk3UT_AchievementTrackerRows.lua
@@ -30,6 +30,45 @@ local ENTRY_ROW_TYPES = {
     objective = true,
 }
 
+local function ensureLabelReference(control)
+    if not control then
+        return nil
+    end
+
+    local label = control.label
+    if label and label.GetText then
+        return label
+    end
+
+    if control.GetNamedChild then
+        local named = control:GetNamedChild("Label")
+        if named then
+            control.label = named
+            return named
+        end
+    end
+
+    if control.SetText then
+        control.label = control
+        return control
+    end
+
+    return nil
+end
+
+local function resetRowHeight(control)
+    if not (control and control.SetHeight) then
+        return
+    end
+
+    if control.__nvkBaseHeight == nil and control.GetHeight then
+        control.__nvkBaseHeight = control:GetHeight() or 0
+    end
+
+    local baseline = control.__nvkBaseHeight or 0
+    control:SetHeight(baseline)
+end
+
 local function Call(callback, ...)
     if type(callback) == "function" then
         return callback(...)
@@ -200,6 +239,9 @@ function Rows:ResetControl(control)
     if not control then
         return
     end
+
+    ensureLabelReference(control)
+    resetRowHeight(control)
 
     if control.SetHidden then
         control:SetHidden(true)


### PR DESCRIPTION
### Motivation
- Fix a regression where long quest/achievement entry and objective texts did not expand row heights and caused squeezing or mystery gaps after migration.
- Ensure pooled row controls never retain stale label references or heights that break subsequent measurements.
- Guarantee that measurement of label `GetTextHeight()` happens only after the final `SetWidth`/`SetText` and after alignment is applied.

### Description
- Add `ensureLabelReference` and `resetRowHeight` helpers and call them when acquiring/ resetting pooled controls to restore a reliable `control.label` and a baseline height in `Tracker/Quest/Nvk3UT_QuestTrackerRows.lua` and `Tracker/Achievement/Nvk3UT_AchievementTrackerRows.lua`.
- Normalize objective label usage to rely on a single `control.label` reference (removed mixed `label.label` access) and set final `SetWidth`/`SetText` before measuring in quest rows (`Tracker/Quest/Nvk3UT_QuestTrackerRows.lua`).
- Ensure layout/measurement ordering is correct (measure after alignment/text width is final) and add gated debug metrics logging for the first few rows in `Tracker/Quest/Nvk3UT_QuestTrackerLayout.lua` and `Tracker/Achievement/Nvk3UT_AchievementTracker.lua` to help validate label width, text height, and applied row height.
- Keep visual behavior unchanged (no artificial padding added) and limit debug output to when the central debug flag is enabled; `Fixes #7`.

### Testing
- No automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962768c0fe8832a9d65be1efaa383aa)