### PR TITLE
REFAC: Quest objectives as independent stacked rows

### DIFF
--- a/Tracker/Quest/Nvk3UT_QuestTracker.lua
+++ b/Tracker/Quest/Nvk3UT_QuestTracker.lua
@@ -4203,9 +4203,6 @@ local function AcquireQuestControl(providedControl)
         end)
         control.initialized = true
     end
-    if QuestTrackerRows and QuestTrackerRows.ResetQuestRowObjectives then
-        QuestTrackerRows:ResetQuestRowObjectives(control)
-    end
     control.rowType = "quest"
     control.poolKey = key
     ApplyLabelDefaults(control.label)
@@ -4526,11 +4523,6 @@ local function ConfigureLayoutHelper()
                     return QuestTrackerRows:AcquireObjectiveRow()
                 end
                 return nil
-            end,
-            ResetQuestRowObjectives = function(row)
-                if QuestTrackerRows and QuestTrackerRows.ResetQuestRowObjectives then
-                    return QuestTrackerRows:ResetQuestRowObjectives(row)
-                end
             end,
             ApplyObjectiveRow = function(control, condition)
                 if QuestTrackerRows and QuestTrackerRows.ApplyObjectiveRow then

--- a/Tracker/Quest/Nvk3UT_QuestTracker.lua
+++ b/Tracker/Quest/Nvk3UT_QuestTracker.lua
@@ -4426,28 +4426,8 @@ local function OnQuestViewModelUpdated(viewModel, context)
         return
     end
 
-    if state.conditionPool then
-        state.conditionPool:ReleaseAllObjects()
-    end
-
-    ResetLayoutState()
-
-    local categoryControls
-    local rowControls
-    local rowsByCategory
-
-    if QuestTrackerRows and QuestTrackerRows.BuildOrRebuildRows then
-        rowsByCategory = QuestTrackerRows:BuildOrRebuildRows(state.viewModel)
-        if QuestTrackerRows.GetCategoryControls then
-            categoryControls = QuestTrackerRows:GetCategoryControls()
-        end
-        if QuestTrackerRows.GetRowControls then
-            rowControls = QuestTrackerRows:GetRowControls()
-        end
-    end
-
     if QuestTrackerLayout and QuestTrackerLayout.ApplyLayout then
-        QuestTrackerLayout:ApplyLayout(state.container, categoryControls, rowControls, rowsByCategory)
+        QuestTrackerLayout:ApplyLayout(state.container)
     end
 
     if IsDebugLoggingEnabled() then
@@ -4529,9 +4509,21 @@ local function ConfigureLayoutHelper()
             ApplyBaseColor = ApplyBaseColor,
             ShouldDisplayCondition = ShouldDisplayCondition,
             AcquireQuestControl = AcquireQuestControl,
+            AcquireCategoryRow = function()
+                if QuestTrackerRows and QuestTrackerRows.AcquireCategoryRow then
+                    return QuestTrackerRows:AcquireCategoryRow()
+                end
+                return nil
+            end,
             AcquireQuestRow = function()
                 if QuestTrackerRows and QuestTrackerRows.AcquireQuestRow then
                     return QuestTrackerRows:AcquireQuestRow()
+                end
+                return nil
+            end,
+            AcquireObjectiveRow = function()
+                if QuestTrackerRows and QuestTrackerRows.AcquireObjectiveRow then
+                    return QuestTrackerRows:AcquireObjectiveRow()
                 end
                 return nil
             end,
@@ -4540,9 +4532,9 @@ local function ConfigureLayoutHelper()
                     return QuestTrackerRows:ResetQuestRowObjectives(row)
                 end
             end,
-            ApplyQuestObjectives = function(row, objectives)
-                if QuestTrackerRows and QuestTrackerRows.ApplyObjectives then
-                    return QuestTrackerRows:ApplyObjectives(row, objectives)
+            ApplyObjectiveRow = function(control, condition)
+                if QuestTrackerRows and QuestTrackerRows.ApplyObjectiveRow then
+                    return QuestTrackerRows:ApplyObjectiveRow(control, condition)
                 end
             end,
             DetermineQuestColorRole = DetermineQuestColorRole,
@@ -4555,6 +4547,21 @@ local function ConfigureLayoutHelper()
             UpdateCategoryToggle = UpdateCategoryToggle,
             AcquireCategoryControl = AcquireCategoryControl,
             NormalizeCategoryKey = NormalizeCategoryKey,
+            ReleaseCategoryRow = function(control)
+                if QuestTrackerRows and QuestTrackerRows.ReleaseCategoryRow then
+                    return QuestTrackerRows:ReleaseCategoryRow(control)
+                end
+            end,
+            ReleaseQuestRow = function(control)
+                if QuestTrackerRows and QuestTrackerRows.ReleaseQuestRow then
+                    return QuestTrackerRows:ReleaseQuestRow(control)
+                end
+            end,
+            ReleaseObjectiveRow = function(control)
+                if QuestTrackerRows and QuestTrackerRows.ReleaseObjectiveRow then
+                    return QuestTrackerRows:ReleaseObjectiveRow(control)
+                end
+            end,
             SetCategoryRowsVisible = function(categoryKey, visible)
                 if QuestTrackerRows and QuestTrackerRows.SetCategoryRowsVisible then
                     return QuestTrackerRows:SetCategoryRowsVisible(categoryKey, visible)
@@ -4592,6 +4599,9 @@ local function ConfigureRowsHelper()
             UpdateContentSize = UpdateContentSize,
             NotifyHostContentChanged = NotifyHostContentChanged,
             ProcessPendingExternalReveal = ProcessPendingExternalReveal,
+            AcquireConditionControl = AcquireConditionControl,
+            FormatConditionText = FormatConditionText,
+            GetQuestTrackerColor = GetQuestTrackerColor,
         })
     end
 end

--- a/Tracker/Quest/Nvk3UT_QuestTrackerLayout.lua
+++ b/Tracker/Quest/Nvk3UT_QuestTrackerLayout.lua
@@ -582,10 +582,6 @@ function Layout:ApplyRowDescriptor(rowDescriptor, providedControl)
             return nil
         end
 
-        if self.deps.ResetQuestRowObjectives then
-            self.deps.ResetQuestRowObjectives(control)
-        end
-
         local quest = rowDescriptor.quest or {}
         control.data = { quest = quest }
         control.questJournalIndex = quest and quest.journalIndex


### PR DESCRIPTION
### Motivation

- Fix multiline wrapping and row height issues by making every visible line an independent stacked row instead of child-anchored objectives.
- Preserve all existing spacing/indent behavior, left/right alignment, and expand/collapse semantics from v0.17.5. 
- Avoid changing how quests/objectives are fetched or normalized and keep layout math/spacing identical by reusing the existing spacing constants via the `deps` interface. 

### Description

- Added a flat row builder `Layout:BuildFlatRowList` and a per-descriptor renderer `Layout:ApplyRowDescriptor` so category/quest/condition rows are produced and rendered in strict visual order. 
- Refactored `Layout:ApplyLayout` to iterate the flat list and stack rows (category, quest, objective) independently, anchoring each row and applying the exact same spacing/indent rules via `deps` values. 
- Converted objective controls into first-class rows: added `AcquireCategoryRow`, `AcquireObjectiveRow`, `ReleaseCategoryRow`, `ReleaseObjectiveRow`, and `ApplyObjectiveRow` in `Nvk3UT_QuestTrackerRows.lua`, and wired the layout to use these via injected callbacks from `Nvk3UT_QuestTracker.lua`. 
- Removed the fragile parent/child objective height accumulation (quest content height now only measures the quest row) and added a small debug helper `Layout:LogRowMetrics` gated by `isDebugEnabled()` and `DEBUG_ROW_LOG_COUNT` to verify layout parity. 

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696287ef9f6c832a9e401d8be453e250)